### PR TITLE
bug fix: catch file permissions error in utils.copyFilesAndDirs()

### DIFF
--- a/Alloy/utils.js
+++ b/Alloy/utils.js
@@ -281,8 +281,7 @@ exports.copyFilesAndDirs = function(f,d)
 			}
 		}
 		catch (e) {
-			logger.info(e);
-			logger.warn('Could not copy ' + fpath + ': ');
+			logger.warn('Could not copy ' + fpath);
 		}
 	}
 }


### PR DESCRIPTION
I use subversion for source control and noticed that copyFilesAndDirs() was attempting to copy the app/assets/.svn and stopping on a file permissions error.  This change simply wraps a try/catch around the copy operation and outputs a warning.
