### PR TITLE
Fix 'main' property for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "bin": {
     "alloy": "./bin/alloy"
   },
-  "main": "./Alloy/alloy",
+  "main": "./Alloy/lib/alloy",
   "engines": {
     "node": ">= 0.6.0"
   }


### PR DESCRIPTION
My understanding is that the 'main' property should point to the entry point for the module's library (what actually gets loaded by require('alloy')). The current pointer is at the binary script used to run commands, not the actual library. Without the correct pointer dependent modules and Titanium Studio will not be able to properly load the API.
