### PR TITLE
Initial checkin of dynamic styles and orietnation change prototype

### DIFF
--- a/Alloy/commands/compile/parsers/default.js
+++ b/Alloy/commands/compile/parsers/default.js
@@ -18,18 +18,24 @@ function parse(node, state, args) {
 	}
 
 	// Generate runtime code
-	code += (state.local ? 'var ' : '') + args.symbol + " = " + args.ns + "." + createFunc + "(\n";
-	code += CU.generateStyleParams(
+	code += "__styleParams = " + CU.generateStyleParams(
 		state.styles,
 		args.classes,
 		args.id,
 		CU.getNodeFullname(node),
 		_.defaults(state.extraStyle || {}, args.createArgs || {}),
 		state
-	) + '\n';
+	) + ';\n';
+	if (!state.local) {
+		code += "if (refresh) {\n" + args.symbol + ".applyProperties(__styleParams);\n} else {\n";
+	}		
+	code += (state.local ? 'var ' : '') + args.symbol + " = " + args.ns + "." + createFunc + "(__styleParams\n";	
 	code += ");\n";
 	if (args.parent.symbol) {
 		code += args.parent.symbol + ".add(" + args.symbol + ");\n";
+	}
+	if (!state.local) {
+		code += "}\n";
 	}
 
 	if (isCollectionBound) {


### PR DESCRIPTION
1. Add orientation query handling, I basically copied the
   treatment of formFactor here. The orientation query is
   similar to formFactor: orientation=landscape, or
   orientation=portrait
2. Add an _init() function to controller, which will take
   a refresh parameter. If refresh is false, we initialize
   the controller like before; otherwise we use
   applyProperties to refresh the nodes

I didn't add the actually handling of orientation change
event since I haven't thought about where best to put it.
But basically you should be able to add the orientation
query in tss, then call controller.__init({}, true) in
orientation change event to make the change.
