### PR TITLE
userid and username after social login

### DIFF
--- a/Alloy/builtins/social.js
+++ b/Alloy/builtins/social.js
@@ -535,10 +535,7 @@ var OAuthAdapter = function(pConsumerSecret, pConsumerKey, pSignatureMethod) {
         message.parameters.push([ "oauth_token", requestToken ]), message.parameters.push([ "oauth_verifier", pin ]), OAuth.setTimestampAndNonce(message), OAuth.SignatureMethod.sign(message, accessor);
         var parameterMap = OAuth.getParameterMap(message.parameters), client = Ti.Network.createHTTPClient({
             onload: function() {
-		Ti.API.info("--------------------------------");
-		Ti.API.info(this.responseText);
-	      
-                var responseParams = OAuth.getParameterMap(this.responseText);
+		var responseParams = OAuth.getParameterMap(this.responseText);
 		var userid = responseParams.user_id;
 		var username = responseParams.screen_name;
                 accessToken = responseParams.oauth_token, accessTokenSecret = responseParams.oauth_token_secret, callback({


### PR DESCRIPTION
The oauth function is returning the twitter username and userid. I'll added them as a feedback inside authorize callback. Example:

social.authorize(function(e) {
Ti.API.info("username: " + e.username);
Ti.API.info("username: " + e.userid);
}
