### PR TITLE
[ALOY-620] Added option to disable selective copying of builtins

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -137,6 +137,11 @@ module.exports = function(args, program) {
 	// copy in all lib resources from alloy module
 	U.updateFiles(path.join(alloyRoot, 'lib'), paths.resources);
 	U.updateFiles(path.join(alloyRoot, 'common'), path.join(paths.resources,'alloy'));
+	
+	// copy all builtins if requested
+	if (compileConfig.alloyConfig.builtins === 'false') {
+		U.updateFiles(path.join(alloyRoot, 'builtins'), path.join(paths.resources,'alloy'));
+	}
 
 	// create runtime folder structure for alloy
 	_.each(['COMPONENT','WIDGET','RUNTIME_STYLE'], function(type) {
@@ -679,6 +684,11 @@ function optimizeCompiledCode() {
 				return f.indexOf(e) === 0; 
 			});
 		});
+	}
+	
+	// Skip selective builtins
+	if (compileConfig.alloyConfig.builtins === 'false') {
+		mods = _.without(mods, 'builtins');
 	}
 
 	while((files = _.difference(getJsFiles(),lastFiles)).length > 0) {

--- a/Alloy/commands/compile/sourceMapper.js
+++ b/Alloy/commands/compile/sourceMapper.js
@@ -101,6 +101,9 @@ exports.generateCodeAndSourceMap = function(generator, compileConfig) {
 
 	// process all AST operations
 	_.each(mods, function(mod) {
+		// Skip selective builtins
+		if (mod === 'builtins' && config.alloyConfig.builtins === 'false') return;
+		
 		logger.trace('- Processing "' + mod + '" module...');
 		ast.figure_out_scope();
 		ast = require(modLocation+mod).process(ast, compileConfig) || ast;


### PR DESCRIPTION
Another option to speed up compilation during development, by just copying all instead of only used builtins. This will speed up in particular if we also add the option to not cleanup on each compile.
