### PR TITLE
fix to alloy deeper database references

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -373,10 +373,9 @@ function installDatabase(config) {
 	// get the database name from the db file path
 	var dbFile = config.adapter.db_file;
 	var table = config.adapter.collection_name;
-  var dbFileName = dbFile.replace(/^.*[\\\/]/, ''a);
 
-	var rx = /^([\/]{0,1})([^\/]+)\.[^\/]+$/;
-	var match = dbFileName.match(rx);
+  var rx = /(^|.*\/)([^\/]+)\.[^\/]+$/;
+	var match = dbFile.match(rx);
 	if (match === null) {
 		throw 'Invalid sql database filename "' + dbFile + '"';
 	}


### PR DESCRIPTION
Ticket: [https://jira.appcelerator.org/browse/ALOY-735](https://jira.appcelerator.org/browse/ALOY-735)

This is an important fix that allows the database file reference to be for example:

`/databases/database.sql`

or

`file://localhost/Users/david/Library/Application%20Support/iPhone%20Simulator/6.1/Applications/9D1B9309-4E51-4FB2-A625-ED271FDECC31/Documents//AlloyTest//myapp.sqlite`

Will fix this TiShadow issue: https://github.com/dbankier/TiShadow/issues/78
