### PR TITLE
Fix for TC-2561

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -379,7 +379,7 @@ function installDatabase(config) {
 		throw 'Invalid sql database filename "' + dbFile + '"';
 	}
 	//var isAbsolute = match[1] ? true : false;
-	var dbName = config.adapter.db_name = match[2];
+	var dbName = config.adapter.db_name || match[2];
 
 	// install and open the preloaded db
 	Ti.API.debug('Installing sql database "' + dbFile + '" with name "' + dbName + '"');


### PR DESCRIPTION
Typo fix for https://jira.appcelerator.org/browse/TC-2561 causing `db_name` not to work when using `db_file` as well.
