### PR TITLE
[ALOY-575] widgets no longer require a "views" folder, test app included

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -215,33 +215,39 @@ module.exports = function(args, program) {
 	var tracker = {};
 	_.each(viewCollection, function(collection) {
 		// generate runtime controllers from views
-		_.each(wrench.readdirSyncRecursive(path.join(collection.dir,CONST.DIR.VIEW)), function(view) {
-			if (viewRegex.test(view) && filterRegex.test(view)) {
-				// make sure this controller is only generated once
-				var fp = path.join(collection.dir,view.substring(0,view.lastIndexOf('.')));
-				if (tracker[fp]) { return; }
+		var theViewDir = path.join(collection.dir,CONST.DIR.VIEW);
+		if (fs.existsSync(theViewDir)) {
+			_.each(wrench.readdirSyncRecursive(theViewDir), function(view) {
+				if (viewRegex.test(view) && filterRegex.test(view)) {
+					// make sure this controller is only generated once
+					var fp = path.join(collection.dir,view.substring(0,view.lastIndexOf('.')));
+					if (tracker[fp]) { return; }
 
-				// generate runtime controller
-				logger.info('[' + view + '] ' + (collection.manifest ? collection.manifest.id + ' ' : '') + 'view processing...');
-				parseAlloyComponent(view, collection.dir, collection.manifest);
-				tracker[fp] = true;
-			}
-		});
+					// generate runtime controller
+					logger.info('[' + view + '] ' + (collection.manifest ? collection.manifest.id + ' ' : '') + 'view processing...');
+					parseAlloyComponent(view, collection.dir, collection.manifest);
+					tracker[fp] = true;
+				}
+			});
+		}
 
 		// generate runtime controllers from any controller code that has no 
 		// corresponding view markup
-		_.each(wrench.readdirSyncRecursive(path.join(collection.dir,CONST.DIR.CONTROLLER)), function(controller) {
-			if (controllerRegex.test(controller) && filterRegex.test(controller)) {
-				// make sure this controller is only generated once
-				var fp = path.join(collection.dir,controller.substring(0,controller.lastIndexOf('.')));
-				if (tracker[fp]) { return; }
+		var theControllerDir = path.join(collection.dir,CONST.DIR.CONTROLLER);
+		if (fs.existsSync(theControllerDir)) {
+			_.each(wrench.readdirSyncRecursive(theControllerDir), function(controller) {
+				if (controllerRegex.test(controller) && filterRegex.test(controller)) {
+					// make sure this controller is only generated once
+					var fp = path.join(collection.dir,controller.substring(0,controller.lastIndexOf('.')));
+					if (tracker[fp]) { return; }
 
-				// generate runtime controller
-				logger.info('[' + controller + '] ' + (collection.manifest ? collection.manifest.id + ' ' : '') + 'controller processing...');
-				parseAlloyComponent(controller, collection.dir, collection.manifest, true);
-				tracker[fp] = true;
-			}
-		});
+					// generate runtime controller
+					logger.info('[' + controller + '] ' + (collection.manifest ? collection.manifest.id + ' ' : '') + 'controller processing...');
+					parseAlloyComponent(controller, collection.dir, collection.manifest, true);
+					tracker[fp] = true;
+				}
+			});
+		}
 	});
 	logger.info('');
 

--- a/test/apps/testing/ALOY-525/config.json
+++ b/test/apps/testing/ALOY-525/config.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"test.widget": "1.0"
+	}
+}

--- a/test/apps/testing/ALOY-525/controllers/index.js
+++ b/test/apps/testing/ALOY-525/controllers/index.js
@@ -1,0 +1,3 @@
+$.index.open();
+
+Alloy.createWidget('test.widget').sayHello();

--- a/test/apps/testing/ALOY-525/styles/index.tss
+++ b/test/apps/testing/ALOY-525/styles/index.tss
@@ -1,0 +1,5 @@
+'#index': {
+	backgroundColor: '#fff',
+	fullscreen: false,
+	exitOnClose: true
+}

--- a/test/apps/testing/ALOY-525/views/index.xml
+++ b/test/apps/testing/ALOY-525/views/index.xml
@@ -1,0 +1,5 @@
+<Alloy>
+	<Window>
+		<Label>Testing a widget...</Label>
+	</Window>
+</Alloy>

--- a/test/apps/testing/ALOY-525/widgets/test.widget/controllers/widget.js
+++ b/test/apps/testing/ALOY-525/widgets/test.widget/controllers/widget.js
@@ -1,0 +1,3 @@
+exports.sayHello = function() {
+	alert('hello!');
+}

--- a/test/apps/testing/ALOY-525/widgets/test.widget/widget.json
+++ b/test/apps/testing/ALOY-525/widgets/test.widget/widget.json
@@ -1,0 +1,14 @@
+{
+	"id": "test.widget",
+	"name": "Test Widget",
+	"description" : "my test widget",
+	"author": "Tony Lukasavage",
+	"version": "1.0",
+	"copyright":"Copyright (c) 2012 by Tony Lukasavage",
+	"license":"Public Domain",
+	"min-alloy-version": "1.2",
+	"min-titanium-version":"3.1",
+	"tags":"",
+	"platforms":"android,ios,mobileweb,blackberry",
+	"dependencies": {}
+}


### PR DESCRIPTION
This branch was mis-named ALOY-525, it should be ALOY-575

Ticket: [https://jira.appcelerator.org/browse/ALOY-575](https://jira.appcelerator.org/browse/ALOY-575)
