### PR TITLE
[ALOY-740] Remove redundant "(Alloy)" from sample app names

### DIFF
--- a/Alloy/commands/info/index.js
+++ b/Alloy/commands/info/index.js
@@ -27,19 +27,19 @@ var info = {
 		var desc = [
 			{
 				name: "mapping", 
-				label: "Geocoder (Alloy)", 
+				label: "Geocoder", 
 				Description: "A sample app that uses native maps to plot locations. With it you can forward geocode addresses and add them as annotations to the map.", 
 				icon: "app.png"
 			},
   			{
   				name: "rss", 
-  				label: "RSS Reader (Alloy)", 
+  				label: "RSS Reader", 
   				Description: "A sample Master/Detail app that creates a RSS reader. With it you can pull live RSS feeds from the internet, list them along with thumbnails, then drill down to the article itself.", 
   				icon: "app.png"
   			},
   			{
   				name: "todo", 
-  				label: "Todo List (Alloy)", 
+  				label: "Todo List", 
   				Description: "A sample application that creates a basic todo list. With this app you can maintain a listing of tasks to be completed, add to that list, and mark tasks as done, all powered by Alloy models and collections.", 
   				icon: "app.png"
   			}


### PR DESCRIPTION
Ticket: [https://jira.appcelerator.org/browse/ALOY-740](https://jira.appcelerator.org/browse/ALOY-740)
