### PR TITLE
[ALOY-611] Give explicit message stating that ListView can only use Titanium APIs as template elements

### DIFF
--- a/Alloy/commands/compile/parsers/Alloy.Abstract.ItemTemplate.js
+++ b/Alloy/commands/compile/parsers/Alloy.Abstract.ItemTemplate.js
@@ -52,6 +52,15 @@ function parse(node, state, args) {
 		code += 'var ' + childTemplates + '=[];';
 
 		_.each(children, function(child) {
+			if (child.nodeName === 'Require' || child.nodeName === 'Widget') {
+				U.dieWithNode(child, [
+					'<ItemTemplate> cannot contain <Require> or <Widget> elements.',
+					'ListView currently only supports Titanium API elements:',
+					'  examples: <Label>, <Button>, <ImageView>, etc...',
+					'Please reference the ListView guide at docs.appcelerator.com for more details.'
+				]);
+			}
+
 			code += CU.generateNodeExtended(child, state, {
 				parent: {},
 				local: true,


### PR DESCRIPTION
Ticket: [https://jira.appcelerator.org/browse/ALOY-611](https://jira.appcelerator.org/browse/ALOY-611)
