### PR TITLE
Update social.js

### DIFF
--- a/Alloy/builtins/social.js
+++ b/Alloy/builtins/social.js
@@ -575,7 +575,7 @@ var OAuthAdapter = function(pConsumerSecret, pConsumerKey, pSignatureMethod) {
         accessToken: "https://api.twitter.com/oauth/access_token",
         requestToken: "https://api.twitter.com/oauth/request_token",
         authorize: "https://api.twitter.com/oauth/authorize?",
-        update: "https://api.twitter.com/1/statuses/update.json"
+        update: "https://api.twitter.com/1.1/statuses/update.json"
     }
 };
 


### PR DESCRIPTION
Updated to use v1.1 of the Twitter API as V1 is now deprecated.
