### PR TITLE
fixes #TC-2779: multiple widgets won't build in the same app

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -223,14 +223,14 @@ module.exports = function(args, program) {
 				if (viewRegex.test(view) && filterRegex.test(view)) {
 					// make sure this controller is only generated once
 					var theFile = view.substring(0, view.lastIndexOf('.'));
-					var fp = path.join(collection.dir, theFile);
 					var theKey = theFile.replace(new RegExp('^' + buildPlatform + '[\\/\\\\]'), '');
-					if (tracker[theKey]) { return; }
+					var fp = path.join(collection.dir, theKey);
+					if (tracker[fp]) { return; }
 
 					// generate runtime controller
 					logger.info('[' + view + '] ' + (collection.manifest ? collection.manifest.id + ' ' : '') + 'view processing...');
 					parseAlloyComponent(view, collection.dir, collection.manifest);
-					tracker[theKey] = true;
+					tracker[fp] = true;
 				}
 			});
 		}
@@ -243,14 +243,14 @@ module.exports = function(args, program) {
 				if (controllerRegex.test(controller) && filterRegex.test(controller)) {
 					// make sure this controller is only generated once
 					var theFile = controller.substring(0,controller.lastIndexOf('.'));
-					var fp = path.join(collection.dir, theFile);
 					var theKey = theFile.replace(new RegExp('^' + buildPlatform + '[\\/\\\\]'), '');
-					if (tracker[theKey]) { return; }
+					var fp = path.join(collection.dir, theKey);
+					if (tracker[fp]) { return; }
 
 					// generate runtime controller
 					logger.info('[' + controller + '] ' + (collection.manifest ? collection.manifest.id + ' ' : '') + 'controller processing...');
 					parseAlloyComponent(controller, collection.dir, collection.manifest, true);
-					tracker[theKey] = true;
+					tracker[fp] = true;
 				}
 			});
 		}


### PR DESCRIPTION
Since the resolution of [ALOY-659](https://jira.appcelerator.org/browse/ALOY-659) through [this commit](https://github.com/appcelerator/alloy/commit/76f34fec73476426f49b423de8f31b6a1bf45e66) there's a bug when tracking the files already compiled to `Resources`. Controllers or views for which another file with the same path (but in an other directory) exist are simply ignored.

This is obviously the case with widgets's `widget.js` files. Say we have two widgets:
- app/widgets/firstWidget/controllers/widget.js
- app/widgets/anOtherWidget/controllers/widget.js

Both of these widgets will be added in the tracker collection with the key "`widget`", resulting with only the first loaded widget.js file being handheld by alloy.

The associated Jira issue is https://jira.appcelerator.org/browse/TC-2779
