### PR TITLE
[ALOY-802] Fixed escaping of __controllerPath for template

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -313,7 +313,7 @@ function parseAlloyComponent(view, dir, manifest, noView) {
 			modelVariable: CONST.BIND_MODEL_VAR,
 			parentVariable: CONST.PARENT_SYMBOL_VAR,
 			itemTemplateVariable: CONST.ITEM_TEMPLATE_VAR,
-			controllerPath: dirname ? path.join(dirname,viewName) : viewName,
+			controllerPath: (dirname ? path.join(dirname,viewName) : viewName).replace(/\\/g, '\\\\'),
 			preCode: '',
 			postCode: '',
 			Widget: !manifest ? '' : 'var ' + CONST.WIDGET_OBJECT +


### PR DESCRIPTION
Ticket: [https://jira.appcelerator.org/browse/ALOY-802](https://jira.appcelerator.org/browse/ALOY-802)
