### PR TITLE
enable --platform for compile command

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -65,6 +65,10 @@ module.exports = function(args, program) {
 			logger.debug(parts[0] + ' = ' + parts[1]);
 		});
 	}
+	if (program.platform) {
+		logger.debug('platform = ' + program.platform);
+		alloyConfig.platform = program.platform;
+	}
 	if (!alloyConfig.deploytype) {
 		alloyConfig.deploytype = 'development';
 		logger.debug('deploytype = ' + alloyConfig.deploytype);


### PR DESCRIPTION
`alloy compile --config platform=ios` is pretty verbose.

The `--platform` or `-q` flag is already there so why not use it?

`alloy compile --platform=ios` is cleaner
