### PR TITLE
[ALOY-871] Extend custom formFactor

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -580,6 +580,9 @@ exports.createCompileConfig = function(inputPath, outputPath, alloyConfig) {
 		configs.adapters = [configs.adapters];
 	}
 
+	// extend formFactors from config.json
+	_.extend(exports.CONDITION_MAP, configs.formFactors);
+
 	logger.debug(JSON.stringify(configs, null, '  ').split(os.EOL));
 
 	// update implicit namespaces, if possible

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -376,10 +376,10 @@ exports.generateStyleParams = function(styles,classes,id,apiName,extraStyle,theS
 				}
 
 				// handle formFactor device query
-				if (q.formFactor === 'tablet') {
-					conditionals.formFactor = 'Alloy.isTablet';
-				} else if (q.formFactor === 'handheld') {
-					conditionals.formFactor = 'Alloy.isHandheld';
+				if(CU.CONDITION_MAP[q.formFactor]){
+					conditionals.formFactor=CU.CONDITION_MAP[q.formFactor]['runtime'];
+				}else{
+					logger.warn('Unknown formFactor "'+q.formFactor+'"');
 				}
 
 				// assemble runtime query


### PR DESCRIPTION
You can extend custom formFactor dynamically.

check this example,
- xml

``` xml
<View formFactor="tall" backgroundColor ="red"></View>
```
- tss

``` javascript
".thumb[formFactor=iOS7]":{
        borderColor : 'red'
}
```
- config.json

``` json
{
    "global": {}, 
    "env:development": {}, 
    "env:test": {}, 
    "env:production": {}, 
    "os:ios": {}, 
    "os:android": {}, 
    "dependencies": {},
    "formFactors" : {
        "iOS7":{
            "runtime" : "Alloy.Globals.isIOS7"
        },
        "tall":{
            "runtime" : "Ti.Platform.displayCaps.platformHeight<500"
        }
    }
}
```
- alloy.js

``` javascript
Alloy.Globals.isIOS7 = Ti.Platform.name == 'iPhone OS' && parseInt(Ti.Platform.version)>=7;
```

Now you can make any formFactor such as 'SamsunGalaxy3', 'Nexus'.
