### PR TITLE
Declare Alloy before inserting model definition

### DIFF
--- a/Alloy/template/model.js
+++ b/Alloy/template/model.js
@@ -1,8 +1,8 @@
-<%= modelJs %>
-
 var Alloy = require('alloy'),
     _ = require("alloy/underscore")._,
 	model, collection;
+	
+<%= modelJs %>
 
 model = Alloy.M('<%= basename %>',
 	 exports.definition,


### PR DESCRIPTION
This way you can use `Alloy.CFG.foo` in the definition.
