### PR TITLE
[TIMOB-15402] Unable to add NavigationWindow to Popover.

### DIFF
--- a/Alloy/commands/compile/parsers/Alloy.Abstract.ContentView.js
+++ b/Alloy/commands/compile/parsers/Alloy.Abstract.ContentView.js
@@ -1,0 +1,12 @@
+var _ = require('../../../lib/alloy/underscore')._;
+
+exports.parse = function(node, state) {
+	_.extend(state, {
+		proxyPropertyDefinition: {
+			parents: [
+				'Ti.UI.iPad.Popover'
+			]
+		}
+	});
+	return require('./Alloy.Abstract._ProxyProperty').parse(node, state);
+};

--- a/Alloy/common/constants.js
+++ b/Alloy/common/constants.js
@@ -142,6 +142,7 @@ exports.IMPLICIT_NAMESPACES = {
 	ButtonName: NS_ALLOY_ABSTRACT,
 	BarItemTypes: NS_ALLOY_ABSTRACT,
 	BarItemType: NS_ALLOY_ABSTRACT,
+	ContentView: NS_ALLOY_ABSTRACT,
 	CoverFlowImageTypes: NS_ALLOY_ABSTRACT,
 	CoverFlowImageType: NS_ALLOY_ABSTRACT,
 	FlexSpace: NS_ALLOY_ABSTRACT,

--- a/test/apps/ui/popover/controllers/index.js
+++ b/test/apps/ui/popover/controllers/index.js
@@ -1,7 +1,16 @@
 function openPopover() {
 	if (Ti.Platform.osname === 'ipad') {
 		var popover = Alloy.createController('popover').getView();
-		popover.show({view:$.button});
+		popover.show({view:$.button1});
+	} else {
+		alert('Popover only supported on iPad');
+	}
+}
+
+function openPopoverWithContentView() {
+	if (Ti.Platform.osname === 'ipad') {
+		var popover = Alloy.createController('popover_with_content_view').getView();
+		popover.show({view:$.button2});
 	} else {
 		alert('Popover only supported on iPad');
 	}

--- a/test/apps/ui/popover/controllers/popover_with_content_view.js
+++ b/test/apps/ui/popover/controllers/popover_with_content_view.js
@@ -1,0 +1,8 @@
+
+
+function open_window(e) {
+	var win = Ti.UI.createWindow({
+		backgroundColor: "blue"
+	});
+	$.navWindow.openWindow(win, { animated: true });
+}

--- a/test/apps/ui/popover/views/index.xml
+++ b/test/apps/ui/popover/views/index.xml
@@ -1,5 +1,6 @@
 <Alloy>
-	<Window>
-		<Button id="button" onClick="openPopover">popover</Button>
+	<Window layout="vertical">
+		<Button id="button1" onClick="openPopover" top="20">popover</Button>
+		<Button id="button2" onClick="openPopoverWithContentView">popover with content view</Button>
 	</Window>
 </Alloy>

--- a/test/apps/ui/popover/views/popover_with_content_view.xml
+++ b/test/apps/ui/popover/views/popover_with_content_view.xml
@@ -1,0 +1,14 @@
+<Alloy>
+	<Popover title="popover" height="300" width="250">
+		<ContentView>
+			<NavigationWindow id="navWindow">
+				<Window>
+					<RightNavButton>
+						<Button title="Open Window" onClick="open_window"/>
+					</RightNavButton>
+					<Label>This is a window in a popover</Label>
+				</Window>
+			</NavigationWindow>
+		</ContentView>
+	</Popover>
+</Alloy>


### PR DESCRIPTION
Added a new optional tag to set the contentView proxy property of Ti.UI.iPad.Popover.  Extended the existing ui/popover test app to include a popover with a NavigationWindow child in addition to the existing use case.
