### PR TITLE
Fixes a bug in underscore with android. 

### DIFF
--- a/Alloy/lib/alloy/underscore.js
+++ b/Alloy/lib/alloy/underscore.js
@@ -631,7 +631,8 @@
   // during a given window of time.
   _.throttle = function(func, wait) {
     var context, args, result;
-    var previous, timeout = 0;
+    var previous = 0;
+    var timeout = 0;
     var later = function() {
       previous = new Date;
       timeout = 0;


### PR DESCRIPTION
clearTimeout called with undefined or null causes a crash on android platform.
I've sent the CLA just five minutes ago.
