### PR TITLE
[ALOY-963] Allow platform specific subfolders in lib and vendor directories

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -158,14 +158,12 @@ module.exports = function(args, program) {
 		var opts = {
 			rootDir: paths.project
 		};
-		if (type === 'ASSETS') {
-			opts = _.extend(opts, {
-				themeChanged: buildLog.data.themeChanged,
-				filter: new RegExp('^(?:' + otherPlatforms.join('|') + ')[\\/\\\\]'),
-				exceptions: otherPlatforms,
-				titaniumFolder: titaniumFolder
-			});
-		}
+		opts = _.extend(opts, {
+			themeChanged: buildLog.data.themeChanged,
+			filter: new RegExp('^(?:' + otherPlatforms.join('|') + ')[\\/\\\\]'),
+			exceptions: otherPlatforms,
+			titaniumFolder: titaniumFolder
+		});
 		updateFilesWithBuildLog(
 			path.join(paths.app, CONST.DIR[type]),
 			path.join(paths.resources, titaniumFolder),


### PR DESCRIPTION
I wanted to reintroduce platform specific folder in the lib and vendor directories, which was working on previous versions of alloy.
