### PR TITLE
Use the default alloy_id when using the fetch by id shorthand

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -215,7 +215,7 @@ function Sync(method, model, opts) {
 			if (opts.query) {
 				sql = opts.query;
 			} else if (opts.id) {
-				sql += ' WHERE ' + model.idAttribute + ' = ' + opts.id;
+				sql += ' WHERE ' + (model.idAttribute ? model.idAttribute : ALLOY_ID_DEFAULT) + ' = ' + (_.isString(opts.id) ? '"' + opts.id + '"' : opts.id);
 			}
 
 			// execute the select query


### PR DESCRIPTION
As described in https://jira.appcelerator.org/browse/TC-3980, when using default alloy_id's in the models, the fetch shorthand don't work correctly.
