### PR TITLE
Correct month value used in generated file names, e.g. migrations

### DIFF
--- a/Alloy/commands/generate/generateUtils.js
+++ b/Alloy/commands/generate/generateUtils.js
@@ -18,7 +18,7 @@ function pad(x) {
 
 exports.generateMigrationFileName = function(t) {
 	var d = new Date();
-	var s = String(d.getUTCFullYear()) + String(pad(d.getUTCMonth())) +
+	var s = String(d.getUTCFullYear()) + String(pad(d.getUTCMonth() + 1)) +
 		String(pad(d.getUTCDate())) + String(pad(d.getUTCHours())) +
 		String(pad(d.getUTCMinutes())) + String(d.getUTCMilliseconds());
 	return s + '_' + t;


### PR DESCRIPTION
This minor change results in generated filename with correct month values. (JS date, january = 0)
