### PR TITLE
[ALOY-1046] Fixed bug where the initial state of the buttongrid was never...

### DIFF
--- a/test/apps/widgets/widget_buttongrid/controllers/index.js
+++ b/test/apps/widgets/widget_buttongrid/controllers/index.js
@@ -2,7 +2,9 @@ var animation = require('alloy/animation');
 
 function IndexOpen(e) {
     $.logo.init({ image: '/images/alloy.png', width: 216, height: 200, opacity: 0.1 });
-    $.buttongrid.relayout(e);
+    setTimeout(function () {
+    	$.buttongrid.relayout(e);
+    }, 1);
 }
 
 var red = '#900A05';


### PR DESCRIPTION
[ALOY-1046] Fixed bug where the initial state of the buttongrid was never computed before being re-layed out because Mobile Web uses a timer to do the rendering. By adding a setTimeout(), we allow Mobile Web to compute the layout of the newly added elements before triggering the animation.
