### PR TITLE
[ALOY-1042] Themes/Assets images not always correctly applied when using same theme for multiple platforms

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -191,7 +191,7 @@ module.exports = function(args, program) {
 				path.join(paths.resources, titaniumFolder),
 				{
 					rootDir: paths.project,
-					themeChanged: buildLog.data.themeChanged,
+					themeChanged: true,
 					filter: new RegExp('^(?:' + otherPlatforms.join('|') + ')[\\/\\\\]'),
 					exceptions: otherPlatforms,
 					titaniumFolder: titaniumFolder


### PR DESCRIPTION
On first compilation theme assets are copied to the Resources/<platform> folder, on subsequent compilation, regardless of the platform, theme assets are not copied over. 
