### PR TITLE
Fixes sourceMapper being run on non-JS files

### DIFF
--- a/Alloy/utils.js
+++ b/Alloy/utils.js
@@ -240,7 +240,7 @@ exports.updateFiles = function(srcDir, dstDir, opts) {
 				exports.copyFileSync(src, dst);
 			}
 		}
-		if(!srcStat.isDirectory() && opts.createSourceMap) {
+		if(!srcStat.isDirectory() && opts.createSourceMap && path.extname(src) === '.js') {
 			var tpath = path.join(opts.rootDir,'build','map','Resources',(opts.compileConfig.alloyConfig.platform === 'ios' ? 'iphone' : opts.compileConfig.alloyConfig.platform),'alloy');
 			var target = {
 				filename: path.join(tpath, path.basename(src)),


### PR DESCRIPTION
Not sure if this is the right place to fix this but this does fix the following error, which shows sourceMapper runs on non-JS (`.DS_Store`) files as well and crashes on that:

```
[DEBUG] /Users/fokkezb/dev/apps/timewax/app/lib/DB.js
[TRACE] - Processing "builtins" module...
[TRACE] - Processing "optimizer" module...
[TRACE] - Processing "compress" module...
[DEBUG]   map:        "/Users/fokkezb/dev/apps/timewax/build/map/Resources/iphone/DB.js.map"
[DEBUG] /Users/fokkezb/dev/apps/timewax/app/lib/.DS_Store
[WARN]  : ERROR: Unexpected character '' [/Users/fokkezb/dev/apps/timewax/build/map/Resources/iphone/alloy/.DS_Store:1,0]
[TRACE] Bud%
          @� @ @ @
                  E%DSDB` @ @ @
[DEBUG]   
[DEBUG] /Users/fokkezb/dev/forks/alloy/Alloy/commands/compile/sourceMapper.js:186
[DEBUG]             throw e;
[DEBUG]                   ^
[ERROR]   
[ERROR] (/Users/fokkezb/dev/forks/alloy/node_modules/uglify-js/lib/parse.js:185:18)
[ERROR] (/Users/fokkezb/dev/forks/alloy/node_modules/uglify-js/lib/parse.js:199:11)
[ERROR] (/Users/fokkezb/dev/forks/alloy/node_modules/uglify-js/lib/parse.js:291:9)
[DEBUG]     at Object.next_token [as input] (/Users/fokkezb/dev/forks/alloy/node_modules/uglify-js/lib/parse.js:523:9)
[DEBUG]     at next (/Users/fokkezb/dev/forks/alloy/node_modules/uglify-js/lib/parse.js:616:25)
[DEBUG]     at Object.parse (/Users/fokkezb/dev/forks/alloy/node_modules/uglify-js/lib/parse.js:602:15)
[DEBUG]     at Object.exports.generateSourceMap (/Users/fokkezb/dev/forks/alloy/Alloy/commands/compile/sourceMapper.js:183:18)
[DEBUG]     at /Users/fokkezb/dev/forks/alloy/Alloy/utils.js:258:17
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/fokkezb/dev/forks/alloy/Alloy/lib/alloy/underscore.js:79:11)
[ERROR] Alloy compiler failed
```
