### PR TITLE
[ALOY-793] Build fails if using ' \ ' character as text in styles .tss

### DIFF
--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -275,6 +275,8 @@ exports.loadStyle = function(tssFile) {
 
 		// Add enclosing curly braces, if necessary
 		contents = /^\s*\{[\s\S]+\}\s*$/gi.test(contents) ? contents : '{\n' + contents + '\n}';
+		// [ALOY-793] double-escape '\' in tss
+		contents = contents.replace(/(\s)(\\+)(\s)/g, '$1$2$2$3');
 
 		// Process tss file then convert to JSON
 		var json;

--- a/test/apps/testing/ALOY-793/controllers/index.js
+++ b/test/apps/testing/ALOY-793/controllers/index.js
@@ -1,0 +1,1 @@
+$.index.open();

--- a/test/apps/testing/ALOY-793/styles/index.tss
+++ b/test/apps/testing/ALOY-793/styles/index.tss
@@ -1,0 +1,41 @@
+'#index': {
+	backgroundColor: '#fff',
+	fullscreen: false,
+	exitOnClose: true,
+	layout: "vertical",
+	top: 30
+}
+
+"Label": {
+	width: Ti.UI.FILL,
+	height: Ti.UI.SIZE,
+	color: "#000",
+	textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
+	font: {
+		fontSize: '12dp'
+	},
+	left: 30
+}
+
+".title": {
+	font: {
+		fontSize: '14dp'
+	},
+	top: 50
+}
+
+"#topLabel0": {
+	text: 'no  slash'
+}
+
+"#topLabel1": {
+	text: 'one \ slash, ignored'
+}
+
+"#topLabel2": {
+	text: 'two \\ slashes, should see 1 slash'
+}
+
+"#topLabel3": {
+	text: 'look here \u2764'
+}

--- a/test/apps/testing/ALOY-793/views/index.xml
+++ b/test/apps/testing/ALOY-793/views/index.xml
@@ -1,0 +1,15 @@
+<Alloy>
+	<Window>
+		<Label class="title">In TSS</Label>
+		<Label id='topLabel0' />
+		<Label id='topLabel1' />
+		<Label id='topLabel2' />
+		<Label id='topLabel3' />
+
+		<Label class="title">In XML</Label>
+		<Label>NO SLASH</Label>
+		<Label>ONE \ SLASH, IGNORED</Label>
+		<Label>TWO \\ SLASHES, 1 SLASH APPEARS</Label>
+		<Label>LOOK HERE \u2764</Label>
+	</Window>
+</Alloy>


### PR DESCRIPTION
For https://jira.appcelerator.org/browse/ALOY-793
