### PR TITLE
Speed improvement when selecting a data

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -232,7 +232,7 @@ function Sync(method, model, opts) {
 			var values = [];
 			var fieldNames = [];
 			var fieldCount = _.isFunction(rs.fieldCount) ? rs.fieldCount() : rs.fieldCount;
-			var getField = rs.field;
+			var getField = OS_ANDROID ? rs.field.bind(rs) : rs.field;
 			var i = 0;
 			
 			for (; i < fieldCount; i++) {


### PR DESCRIPTION
- What's the point to check the `fieldCount` in every iteration?

I did also few other changes - improvements. Selecting a data should be now ~50% faster than before. Tested on an iPad 3 with the latest SDK.
