### PR TITLE
[ALOY-1002] Platform-specific folders within a widget's assets are copied unnecessarily to the Resources folder

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -595,8 +595,13 @@ exports.copyWidgetResources = function(resources, resourceDir, widgetId, opts) {
 					path.relative(compilerConfig.dir.project, dest).yellow + '...');
 				U.copyFileSync(source, dest);
 			}
-
 		});
+
+		// [ALOY-1002] Remove ios folder copied from widget
+		var iosDir = path.join(resourceDir, 'ios');
+		if (fs.existsSync(iosDir)) {
+			wrench.rmdirSyncRecursive(iosDir);
+		}
 		logger.trace(' ');
 	});
 


### PR DESCRIPTION
For https://jira.appcelerator.org/browse/ALOY-1002
