### PR TITLE
removed the hardcoded year from widget.json

### DIFF
--- a/Alloy/template/widget.json
+++ b/Alloy/template/widget.json
@@ -4,7 +4,7 @@
 	"description" : "",
 	"author": "",
 	"version": "<%= version %>",
-	"copyright":"Copyright (c) 2012",
+	"copyright":"Copyright (c) <%= new Date().getFullYear() %>",
 	"license":"Public Domain",
 	"min-alloy-version": "1.0",
 	"min-titanium-version":"2.1",


### PR DESCRIPTION
I know it is a trivial pull request, but this removed the 2012 hardcoded date from the widget.json file and replaces it with a single line of JavaScript that dynamically adds the current full year.

all test pass ( yes I actually ran jake test:all)
