### PR TITLE
Simplified creating & updating a record

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -159,49 +159,35 @@ function Sync(method, model, opts) {
 	switch (method) {
 		case 'create':
 		case 'update':
-			resp = (function() {
-				var attrObj = {};
-
-				if (!model.id) {
-					model.id = model.idAttribute === ALLOY_ID_DEFAULT ? guid() : null;
-					attrObj[model.idAttribute] = model.id;
-					model.set(attrObj, { silent: true });
-				}
-
-				// assemble columns and values
-				var names = [], values = [], q = [];
-				for (var k in columns) {
-					names.push(k);
-					values.push(model.get(k));
-					q.push("?");
-				}
-
-				// execute the query
-				sql = "REPLACE INTO " + table + " (" + names.join(",") + ") VALUES (" + q.join(",") + ");";
-				db = Ti.Database.open(dbName);
-				db.execute('BEGIN;');
-				db.execute(sql, values);
-
-				// if model.id is still null, grab the last inserted id
-				if (model.id === null) {
-					var sqlId = "SELECT last_insert_rowid();";
-					var rs = db.execute(sqlId);
-					if (rs && rs.isValidRow()) {
-						model.id = rs.field(0);
-						attrObj[model.idAttribute] = model.id;
-						model.set(attrObj, { silent: true });
-					} else {
-						Ti.API.warn('Unable to get ID from database for model: ' + model.toJSON());
-					}
-					if (rs) { rs.close(); }
-				}
-
-				// cleanup
-				db.execute('COMMIT;');
-				db.close();
-
-				return model.toJSON();
-			})();
+			var attrObj = {};
+			
+			if (!model.id) {
+				model.id = model.idAttribute === ALLOY_ID_DEFAULT ? guid() : null;
+				attrObj[model.idAttribute] = model.id;
+				model.set(attrObj, { silent: true });
+			}
+			
+			// assemble columns and values
+			var names = [], values = [], q = [];
+			
+			for (var k in columns) {
+				names.push(k);
+				values.push(model.get(k));
+				q.push("?");
+			}
+			
+			// execute the query
+			db = Ti.Database.open(dbName);
+			db.execute("REPLACE INTO " + table + " (" + columns.join(",") + ") VALUES (" + q.join(",") + ");", values);
+			
+			if (model.id === null) {
+				model.id = db.lastInsertRowId;
+				attrObj[model.idAttribute] = model.id;
+				model.set(attrObj, { silent: true });
+			}
+			
+			db.close();
+			resp = model.toJSON();
 			break;
 
 		case 'read':


### PR DESCRIPTION
- Deleted TRANSACTION (It was completely pointless in this case)
- Used `db.lastInsertRowId` instead of executing another query...
- I didn't make any benchmark ,but I quess that if somebody is updating/creating many records (models) this improvement will affected a speed (At least a little bit).

// Slightly off topic ,but is it good to have Sync adapter as it is? I mean, if I want to for example save ten models then the database connection is going to be opened and closed ten times, that's not good at all.
