### PR TITLE
Delete method shouldn't reset model's id

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -268,7 +268,6 @@ function Sync(method, model, opts) {
 			db.execute(sql, model.id);
 			db.close();
 
-			model.id = null;
 			resp = model.toJSON();
 			break;
 	}


### PR DESCRIPTION
Model's ID should not be deleted (reseted) in the adapter. The problem is that after the `Sync` is done Backbone will trigger `destroy` which will execute a method called `_onModelEvent` -> `remove` ,but model doesn't have an id anymore ,so it won't be deleted from a collection - set `_byId`. If you try to add a new model to the collection with the same ID, backbone will not allow you to do that because the ID already exists in the set.

Example:

test.js (model)

``` javascript
exports.definition = {
    config: {
        columns: {
            "id": "INTEGER PRIMARY KEY",
            "whatever": "TEXT"
        },
        adapter: {
            idAttribute: "id",
            type: "sql",
            collection_name: "test"
        }
    }
};
```

index.js (controller)

``` javascript
var testCollection = Alloy.createCollection("test");

var model = Alloy.createModel("test", {
    "whatever": "..."
});

model.save();

testCollection.add(model);

console.log("Models in `testCollection`: " + testCollection.length + ", Model ID: " + model.id);

model.destroy();

console.log("Models in `testCollection`: " + testCollection.length + ", Model ID: " + model.id);


var newModel = Alloy.createModel("test", {
    "whatever": "---"
});

newModel.save();
testCollection.add(newModel); // Won't add this model

console.log("Models in `testCollection`: " + testCollection.length + ", Model ID: " + newModel.id);
```
