### PR TITLE
[ALOY-1157] Delayed copying of project template files

### DIFF
--- a/Alloy/commands/new/index.js
+++ b/Alloy/commands/new/index.js
@@ -46,11 +46,6 @@ module.exports = function(args, program) {
 	// add the default alloy.js file
 	U.copyFileSync(path.join(paths.template,'alloy.js'), path.join(paths.app,'alloy.js'));
 
-	// add alloy project template files
-	var tplPath = (!program.testapp) ? path.join(paths.projectTemplate,'app') : paths.projectTemplate;
-	wrench.copyDirSyncRecursive(tplPath, paths.app, {preserve:true});
-	fs.writeFileSync(path.join(paths.app,'README'), fs.readFileSync(paths.readme,'utf8'));
-
 	// install ti.alloy compiler plugin
 	U.installPlugin(path.join(paths.alloy,'..'), paths.project);
 
@@ -82,6 +77,11 @@ module.exports = function(args, program) {
 			{preserve:true}
 		);
 	});
+
+	// add alloy project template files
+	var tplPath = (!program.testapp) ? path.join(paths.projectTemplate,'app') : paths.projectTemplate;
+	wrench.copyDirSyncRecursive(tplPath, paths.app, {preserve:true});
+	fs.writeFileSync(path.join(paths.app,'README'), fs.readFileSync(paths.readme,'utf8'));
 
 	// if creating from one of the test apps...
 	if(program.testapp) {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1157

This PR addresses an issue with the `alloy new --testapp` option where some assets and style files from the specified test app were missing from the generated Alloy project folder. The reason was that the source project's Resources folders and global app.tss file were getting copied to the project folder after those from the specified testapp.   
### Verification

Create a new Alloy app from the advanced/android_density test app, and run it on an Android device/sim.

```
$ titanium create --name=appname --id=com.domain.appname --platforms=all
$ cd appname
$ alloy new . --testapp advanced/android_density
```

Verify that the generated Alloy project's `app/assets/android/images` folder contains `res-hdpi`, `res-ldpi`, `res-mdpi`, and `res-xhdpi` folders that each contain theImage.png files:

```
├── app
│   ├── README
│   ├── alloy.js
│   ├── assets
│   │   ├── android
│   │   │   ├── appicon.png
│   │   │   ├── default.png
│   │   │   └── images
│   │   │       ├── res-hdpi
│   │   │       │   └── theImage.png
│   │   │       ├── res-ldpi
│   │   │       │   └── theImage.png
│   │   │       ├── res-long-land-hdpi
│   │   │       │   └── default.png
│   │   │       ├── res-long-land-ldpi
│   │   │       │   └── default.png
│   │   │       ├── res-long-land-mdpi
...................................................................
│   │   │       └── res-xhdpi
│   │   │           └── theImage.png
```
