### PR TITLE
Fixes bug introduced by copy.colors fix

### DIFF
--- a/Alloy/lib/alloy.js
+++ b/Alloy/lib/alloy.js
@@ -643,7 +643,7 @@ function deepExtend() {
 					continue;
 				}
 
-				if (deep && copy && ((_.isObject(copy) && !_.has(copy, 'apiName')) || (copy_is_array = _.isArray(copy))) && !copy.colors) {
+				if (deep && copy && _.isObject(copy) && ((copy_is_array = _.isArray(copy)) || !_.has(copy, 'apiName'))) {
 					// Recurse if we're merging plain objects or arrays
 					if (copy_is_array) {
 						copy_is_array = false;
@@ -659,9 +659,6 @@ function deepExtend() {
 
 				// Don't bring in undefined values
 				} else if (typeof copy !== 'undefined') {
-					target[name] = copy;
-				} else if(copy.colors) {
-					// don't deep merge the colors property of backgroundGradient
 					target[name] = copy;
 				}
 			}


### PR DESCRIPTION
Because `!copy.colors` introduced in https://github.com/appcelerator/alloy/commit/4ed7fd9b8840aaaaf7af71a1a5dbe97a2c43072b was outside the `_.isObject` check it also ran when `copy` was no object, causing a JS exception.

The colors fix was hacky anyway since `} else if(copy.colors) {` never runs because of the `} else if (typeof copy !== 'undefined') {` above it. 

The whole problem of a `colors` array being turned into an object was because the `copy_is_array` statement would not be executed if the the array doesn't include a `apiName` index, since `_.isObject()` is also true for arrays :) Changing the order in the if fixes this.
