### PR TITLE
[ALOY-1104] Android: build fails if there is no assets folder for 1_6_X

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -804,13 +804,11 @@ function generateConfig(obj) {
 		fs.writeFileSync(resourcesCfg, output);
 
 		// TODO: deal with TIMOB-14884
-		if (alloyConfig.platform === 'ios') {
-			var baseFolder = path.join(obj.dir.resources, 'alloy');
-			if (!fs.existsSync(baseFolder)) {
-				wrench.mkdirSyncRecursive(baseFolder, 0755);
-			}
-			fs.writeFileSync(path.join(baseFolder, 'CFG.js'), output);
+		var baseFolder = path.join(obj.dir.resources, 'alloy');
+		if (!fs.existsSync(baseFolder)) {
+			wrench.mkdirSyncRecursive(baseFolder, 0755);
 		}
+		fs.writeFileSync(path.join(baseFolder, 'CFG.js'), output);
 	}
 
 	return o;


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1104
