### PR TITLE
MobileWeb: using 'backbone 1.1.2' dependency, app crashes on MobileWeb for 1_6_X

### DIFF
--- a/Alloy/lib/alloy/backbone/1.1.2/backbone.js
+++ b/Alloy/lib/alloy/backbone/1.1.2/backbone.js
@@ -7,18 +7,18 @@
 
 (function(root, factory) {
 
-  // Set up Backbone appropriately for the environment. Start with AMD.
-  if (typeof define === 'function' && define.amd) {
+  // Set up Backbone appropriately for the environment. Start with Node.js or CommonJS.
+  if (typeof exports !== 'undefined') {
+    var _ = require('alloy/underscore');
+    factory(root, exports, _);
+
+  // Next for AMD.
+  } else if (typeof define === 'function' && define.amd) {
     define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
       // Export global even in AMD case in case this script is loaded with
       // others that may still expect a global Backbone.
       root.Backbone = factory(root, exports, _, $);
     });
-
-  // Next for Node.js or CommonJS. jQuery may not be needed as a module.
-  } else if (typeof exports !== 'undefined') {
-    var _ = require('alloy/underscore');
-    factory(root, exports, _);
 
   // Finally, as a browser global.
   } else {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1161
