### PR TITLE
[ALOY-1198] Update ui/android_menu text for Honeycomb/action bar usage

### DIFF
--- a/test/apps/ui/android_menu/alloy.js
+++ b/test/apps/ui/android_menu/alloy.js
@@ -1,0 +1,1 @@
+Alloy.Globals.hasMenuButton = (Titanium.Platform.Android.API_LEVEL <= 10);

--- a/test/apps/ui/android_menu/views/android/index.xml
+++ b/test/apps/ui/android_menu/views/android/index.xml
@@ -1,6 +1,8 @@
 <Alloy>
 	<Window>
-		<!-- This will add an Android menu -->
+		<!-- On Android 3.0 devices and later, this will add items to the action bar. 
+			 On older Android devices with a physical menu button, it will add items to the
+			 menu that appears when the menu button is pressed.   -->
 		<Menu>
 			<MenuItem title="option 1" icon="/ic_menu_help.png" onClick="doClick"/>
 			<MenuItem title="option 2" icon="/ic_menu_home.png" onClick="openWin2"/>
@@ -8,6 +10,6 @@
 		
 		<!-- Build the rest of your UI as usual -->
 		<Label>Window 1</Label>
-		<Label bottom="20dp">Press the menu button</Label>
+		<Label bottom="20dp" if=Alloy.Globals.hasMenuButton>Press the menu button</Label>
 	</Window>
 </Alloy>


### PR DESCRIPTION
- Updates comments to better reflect how Menu/MenuItem works by default with TI SDK 3.3.0 and later, as action bar items, not the options menu of yore).
- Conditionally displays the "Press the Menu button" label only if the API level is 10 or earlier (pre-Honeycomb).