### PR TITLE
regex change to support {{ }}

### DIFF
--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -16,7 +16,7 @@ var STYLE_ALLOY_TYPE = '__ALLOY_TYPE__';
 var STYLE_EXPR_PREFIX = exports.STYLE_EXPR_PREFIX = '__ALLOY_EXPR__--';
 var STYLE_REGEX = /^\s*([\#\.]{0,1})([^\[]+)(?:\[([^\]]+)\])*\s*$/;
 var EXPR_REGEX = new RegExp('^' + STYLE_EXPR_PREFIX + '(.+)');
-var BINDING_REGEX = /\{([^:}]+)\}/;
+var BINDING_REGEX = /(?:[^\{]|^)\{([^:}]+)\}(?:[^\}]|$)/;
 var VALUES = {
 	ID:     100000,
 	CLASS:   10000,

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -16,7 +16,7 @@ var STYLE_ALLOY_TYPE = '__ALLOY_TYPE__';
 var STYLE_EXPR_PREFIX = exports.STYLE_EXPR_PREFIX = '__ALLOY_EXPR__--';
 var STYLE_REGEX = /^\s*([\#\.]{0,1})([^\[]+)(?:\[([^\]]+)\])*\s*$/;
 var EXPR_REGEX = new RegExp('^' + STYLE_EXPR_PREFIX + '(.+)');
-var BINDING_REGEX = /(?:[^\{]|^)\{([^:}]+)\}(?:[^\}]|$)/;
+var BINDING_REGEX = /\{([^:}]+)\}(?!\})/;
 var VALUES = {
 	ID:     100000,
 	CLASS:   10000,

--- a/test/apps/testing/ALOY-1219/alloy.js
+++ b/test/apps/testing/ALOY-1219/alloy.js
@@ -1,0 +1,18 @@
+Alloy.Models.appState = new Backbone.Model({
+	counter: 1,
+	color: '#00f'
+});
+
+Alloy.Collections.heroes = new Backbone.Collection();
+Alloy.Collections.heroes.reset([
+	{ name: 'Ironman', title: 'Ironman' },
+	{ name: 'Superman', title: 'Superman' },
+	{ name: 'Thor', title: 'Thor' },
+	{ name: 'Captain America', title: 'Captain America' },
+	{ name: 'Hulk', title: 'Hulk' },
+	{ name: 'Green Lantern', title: 'Green Lantern' },
+	{ name: 'Punisher', title: 'Punisher' },
+	{ name: 'Spiderman', title: 'Spiderman' },
+	{ name: 'Wolverine', title: 'Wolverine' },
+	{ name: 'Cyclops', title: 'Cyclops' }
+]);

--- a/test/apps/testing/ALOY-1219/config.json
+++ b/test/apps/testing/ALOY-1219/config.json
@@ -1,0 +1,4 @@
+{
+	"sourcemap": false,
+	"adapters": []
+}

--- a/test/apps/testing/ALOY-1219/controllers/index.js
+++ b/test/apps/testing/ALOY-1219/controllers/index.js
@@ -1,0 +1,37 @@
+var appState = Alloy.Models.appState;
+var heroes = Alloy.Collections.heroes;
+
+function generateRandomColor() {
+	var c =(Math.floor(Math.random()*255))*256*256 +
+		(Math.floor(Math.random()*255))*256 +
+		(Math.floor(Math.random()*255));
+	c = c.toString(16);
+	while (c.length < 6) {
+		c = '0' + c;
+	}
+	return '#' + c;
+}
+
+// Contrived update function to modify the model
+// associated with the clicked row
+function modifyHero(e) {
+	var model = heroes.at(e.index);
+	model.set('name', model.get('name') + '+');
+}
+
+// Update the model's counter and color, which in turn
+// updates the UI via model binding
+function updateState() {
+	appState.set({
+		counter: appState.get('counter')+1,
+		color: generateRandomColor()
+	});
+}
+
+// Simulate a change in our model to trigger UI binding.
+// Remember, don't use fetch() when using a model with
+// no persistence, it will generate an error.
+appState.trigger('change');
+heroes.trigger('change');
+
+$.index.open();

--- a/test/apps/testing/ALOY-1219/styles/app.tss
+++ b/test/apps/testing/ALOY-1219/styles/app.tss
@@ -1,0 +1,17 @@
+"Window": {
+    backgroundColor: '#fff',
+    fullscreen: false,
+    navBarHidden: true
+}
+
+".header": {
+	height: '50dp',
+	width: Ti.UI.FILL,
+	top: 0,
+	textAlign: 'center',
+	color: '#fff',
+	font: {
+		fontSize: '32dp',
+		fontWeight: 'bold'
+	}
+}

--- a/test/apps/testing/ALOY-1219/styles/index.tss
+++ b/test/apps/testing/ALOY-1219/styles/index.tss
@@ -1,0 +1,10 @@
+"#counter": {
+	font: {
+		fontSize: '160dp',
+		fontWeight: 'bold'
+	}
+}
+
+"#table": {
+    top: '50dp'
+}

--- a/test/apps/testing/ALOY-1219/views/index.xml
+++ b/test/apps/testing/ALOY-1219/views/index.xml
@@ -1,0 +1,23 @@
+<Alloy>
+	<TabGroup>
+		<Tab title="model">
+			<Window>
+				<Label class="header" backgroundColor="{appState.color}">Model</Label>
+				<Label id="counter" text="{appState.counter}" color="{appState.color}" onClick="updateState"/>
+			</Window>
+		</Tab>
+		<Tab title="collection">
+			<Window>
+				<Label class="header" backgroundColor="{appState.color}">Collection</Label>
+				<TableView id="table" dataCollection="heroes" onClick="modifyHero">
+          <!-- Then, trying some variations in the data-bound tableview -->
+          <TableViewRow title="{name}"/>
+          <TableViewRow title="My hero is {{name}}"/>
+          <TableViewRow title="{title}, by {name}" />
+          <TableViewRow title="{title} {name}"/>
+          <TableViewRow title="{{name}}"/>
+				</TableView>
+			</Window>
+		</Tab>
+	</TabGroup>
+</Alloy>


### PR DESCRIPTION
Alloy is currently catching and interpreting `{{ }}` as an alloy binding when it should only catch `{ }`.
This change is needed for https://github.com/dbankier/nano.