### PR TITLE
[TIDOC-2058] Added @editurl JSDuck field that contains GitHub edit link for that class/API

### DIFF
--- a/Alloy/builtins/animation.js
+++ b/Alloy/builtins/animation.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins.animation
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/animation.js 
  * A collection of useful animation utilities. To use the animation builtin library,
  * all you need to do is require it with the `alloy` root directory in your
  * `require` call. For example:

--- a/Alloy/builtins/dialogs.js
+++ b/Alloy/builtins/dialogs.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins.dialogs
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/dialogs.js  
  * A collection of utilities for generating dialog boxes.
  * To use the dialogs builtin library,
  * require it with the `alloy` root directory in your `require` call. For example:

--- a/Alloy/builtins/measurement.js
+++ b/Alloy/builtins/measurement.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins.measurement
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/measurement.js
  * A collection of utilities for converting between different display units.
  * These functions are only useful on the Android platform to support devices with different
  * screen densities and resolutions.

--- a/Alloy/builtins/sha1.js
+++ b/Alloy/builtins/sha1.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins.sha1
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/sha1.js  
  * A collection of utilities for calculating SHA-1 or HMAC-SHA-1 values.
  * To use the sha1 builtin library,
  * require it with the `alloy` root directory in your `require` call. For example:

--- a/Alloy/builtins/social.js
+++ b/Alloy/builtins/social.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins.social
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/social.js  
  * A collection of useful social media provider utilities. Currently, this module only supports
  * Twitter and the following features:
  *

--- a/Alloy/builtins/string.js
+++ b/Alloy/builtins/string.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins.string
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/string.js  
  * A collection of utilities for manipulating strings.
  * To use the string builtin library,
  * require it with the `alloy` root directory in your `require` call. For example:

--- a/Alloy/lib/alloy.js
+++ b/Alloy/lib/alloy.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/lib/alloy.js
  * Top-level module for Alloy functions.
  *
  * Alloy is an application framework built on top of the Titanium SDK designed to help rapidly

--- a/Alloy/lib/alloy/controllers/BaseController.js
+++ b/Alloy/lib/alloy/controllers/BaseController.js
@@ -5,6 +5,7 @@ var Alloy = require('alloy'),
 /**
  * @class Alloy.Controller
  * @extends Backbone.Events
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/lib/alloy/controllers/BaseController.js
  * The base class for Alloy controllers.
  *
  * Each controller is associated with a UI hierarchy, defined in an XML file in the

--- a/docs/apidoc/backbone.js
+++ b/docs/apidoc/backbone.js
@@ -1,6 +1,0 @@
-/**
- * @class Backbone.Events
- * @hide
- * Class from which all Alloy controllers are derived.
-
- */

--- a/docs/apidoc/backbone.js
+++ b/docs/apidoc/backbone.js
@@ -1,0 +1,6 @@
+/**
+ * @class Backbone.Events
+ * @hide
+ * Class from which all Alloy controllers are derived.
+
+ */

--- a/docs/apidoc/builtins.js
+++ b/docs/apidoc/builtins.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/builtins.js
  * Alloy provides some additional utility libraries that simplify certain functions,
  * such as animations, string manipultation and display unit conversion.  These libraries
  * are referred to as "builtins."

--- a/docs/apidoc/collection.js
+++ b/docs/apidoc/collection.js
@@ -1,6 +1,7 @@
 /**
  * @class Alloy.Collections
  * Class to access or create collections.
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/collection.js 
  *
  * Collections can either be created in markup or programmatically in the controller.
  *

--- a/docs/apidoc/controller.js
+++ b/docs/apidoc/controller.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.Controller.UI
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/controller.js 
  * 
  * Provides convenience methods for working with Titanium UI objects.
  */

--- a/docs/apidoc/model.js
+++ b/docs/apidoc/model.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.Models
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/model.js 
  * Class to access or create models.
  *
  * Models can either be created in markup or programmatically in the controller.

--- a/docs/apidoc/moment.js
+++ b/docs/apidoc/moment.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.builtins.moment
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/moment.js 
  * Moment.js is a freely distributable, third-party JavaScript date library
  * for parsing, validating, manipulating, and formatting dates.
  *

--- a/docs/apidoc/widgets.js
+++ b/docs/apidoc/widgets.js
@@ -1,5 +1,6 @@
 /**
  * @class Alloy.Widget
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/widgets.js 
  * Widgets are self-contained components that can be easily dropped into an Alloy project.
  * They were conceived as a way to reuse code in multiple projects or to be used multiple
  * times in the same project.


### PR DESCRIPTION
To support https://jira.appcelerator.org/browse/TIDOC-2058.

Note: This step is done automatically for the Titanium docs, since they need to converted from YAML to JSDuck format anyway. Alloy docs are in JSDuck format already, so they are passed as-is to JSDuck for processing. As there are only a few Alloy doc sources, it made sense just to add them manually.