### PR TITLE
fix restrictionPath missing

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -307,7 +307,7 @@ module.exports = function(args, program) {
 					// generate runtime controller
 					logger.info('[' + controller + '] ' + (collection.manifest ?
 						collection.manifest.id + ' ' : '') + 'controller processing...');
-					parseAlloyComponent(controller, collection.dir, collection.manifest, true);
+					parseAlloyComponent(controller, collection.dir, collection.manifest, true, restrictionPath);
 					tracker[fp] = true;
 				}
 			});


### PR DESCRIPTION
add restrictionPath  when call parseAlloyComponent for controller that has no correcpoding view markup

This is a related with appcelerator/alloy#625 ( @xavierlacot )