### PR TITLE
[ALOY-1267] Map DocumentViewer to Ti.UI.iOS

### DIFF
--- a/Alloy/common/constants.js
+++ b/Alloy/common/constants.js
@@ -187,12 +187,12 @@ exports.IMPLICIT_NAMESPACES = {
 	// Ti.UI.iOS
 	AdView: NS_TI_UI_IOS,
 	CoverFlowView: NS_TI_UI_IOS,
+	DocumentViewer: NS_TI_UI_IOS,
 	NavigationWindow: NS_TI_UI_IOS,
 	TabbedBar: NS_TI_UI_IOS,
 	Toolbar: NS_TI_UI_IOS,
 
 	// Ti.UI.iPad
-	DocumentViewer: NS_TI_UI_IPAD,
 	Popover: NS_TI_UI_IPAD,
 	SplitWindow: NS_TI_UI_IPAD,
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/ALOY-1257

Has been moved since 3.0.0: http://docs.appcelerator.com/platform/latest/#!/api/Titanium.UI.iPad.DocumentViewer