### PR TITLE
[ALOY-1278] Pass model config to migration functions

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -365,7 +365,7 @@ function Migrate(Model) {
 			// execute the appropriate migration function
 			var funcName = direction ? 'up' : 'down';
 			if (_.isFunction(context[funcName])) {
-				context[funcName](migrator);
+				context[funcName](migrator, config);
 			}
 		}
 	} else {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TC-5486

It will be nice if sql sync adapter will pass model config to migration functions. It will get access to model columns inside migration for example.

``` javascript
migration.up = function(migrator, config) {
    migrator.createTable(config);
    // other migration actions
};
```
