### PR TITLE
[ALOY-1276] fixes deepExtend()

### DIFF
--- a/Alloy/lib/alloy.js
+++ b/Alloy/lib/alloy.js
@@ -664,9 +664,9 @@ function deepExtend() {
 
 					// Never move original objects, clone them
 					target[name] = deepExtend(deep, clone, copy);
+				} else {
+					target[name] = copy;
 				}
-
-				target[name] = copy;
 			}
 		}
 	}

--- a/Alloy/lib/alloy.js
+++ b/Alloy/lib/alloy.js
@@ -651,7 +651,7 @@ function deepExtend() {
 					continue;
 				}
 
-				if (deep && copy && _.isObject(copy) && ((copy_is_array = _.isArray(copy)) || !_.has(copy, 'apiName'))) {
+				if (deep && copy && !_.isFunction(copy) && _.isObject(copy) && ((copy_is_array = _.isArray(copy)) || !_.has(copy, 'apiName'))) {
 					// Recurse if we're merging plain objects or arrays
 					if (copy_is_array) {
 						copy_is_array = false;


### PR DESCRIPTION
This PR relates to ALOY-1276. Basically, it fixes a bug introduced in 84c9470d9932a5ad762f8220db79802d91ec4c86 which makes Alloy's `deepExtend()` method useless.

It might be a good idea to simple revert commit 84c9470d9932a5ad762f8220db79802d91ec4c86, but it would involve digging into the bug ALOY-1153 in a closer way.