### PR TITLE
[ALOY-1277] made it possible to parse a TSS string directly, not only tss files

### DIFF
--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -268,35 +268,40 @@ exports.loadStyle = function(tssFile) {
 			U.die('Failed to read style file "' + tssFile + '"', e);
 		}
 
-		// skip if the file is empty
-		if (/^\s*$/gi.test(contents)) {
-			return {};
-		}
-
-		// Add enclosing curly braces, if necessary
-		contents = /^\s*\{[\s\S]+\}\s*$/gi.test(contents) ? contents : '{\n' + contents + '\n}';
-		// [ALOY-793] double-escape '\' in tss
-		contents = contents.replace(/(\s)(\\+)(\s)/g, '$1$2$2$3');
-
-		// Process tss file then convert to JSON
-		var json;
-		try {
-			json = grammar.parse(contents);
-			optimizer.optimizeStyle(json);
-		} catch (e) {
-			U.die([
-				'Error processing style "' + tssFile + '"',
-				e.message,
-				/Expected bare word\, comment\, end of line\, string or whitespace but ".+?" found\./.test(e.message) ? 'Do you have an extra comma in your style definition?' : '',
-				'- line:    ' + e.line,
-				'- column:  ' + e.column,
-				'- offset:  ' + e.offset
-			]);
-		}
-
-		return json;
+		return exports.loadStyleFromString(contents, tssFile);
 	}
 	return {};
+};
+
+exports.loadStyleFromString = function(contents, tssFile) {
+	// skip if the file is empty
+	if (/^\s*$/gi.test(contents)) {
+		return {};
+	}
+
+	// Add enclosing curly braces, if necessary
+	contents = /^\s*\{[\s\S]+\}\s*$/gi.test(contents) ? contents : '{\n' + contents + '\n}';
+	// [ALOY-793] double-escape '\' in tss
+	contents = contents.replace(/(\s)(\\+)(\s)/g, '$1$2$2$3');
+
+	// Process tss file then convert to JSON
+	var json;
+
+	try {
+		json = grammar.parse(contents);
+		optimizer.optimizeStyle(json);
+	} catch (e) {
+		U.die([
+			tssFile ? 'Error processing style "' + tssFile + '"' : 'Error processing style',
+			e.message,
+			/Expected bare word\, comment\, end of line\, string or whitespace but ".+?" found\./.test(e.message) ? 'Do you have an extra comma in your style definition?' : '',
+			'- line:    ' + e.line,
+			'- column:  ' + e.column,
+			'- offset:  ' + e.offset
+		]);
+	}
+
+	return json;
 };
 
 exports.loadAndSortStyle = function(tssFile, opts) {


### PR DESCRIPTION
This PR fixes ALOY-1277

At the moment, [Alloy's styler](https://github.com/appcelerator/alloy/blob/master/Alloy/commands/compile/styler.js#L261) only allows to load styles from a file.

In several cases (alternative syntaxes transformations, for instance), it might be useful to be able to load styles from a string. This PR achieves such a goal in a rather simple way - it introduces a `loadStyleFromString()` method, which does the trick. The original `loadStyle()` method calls `loadStyleFromString()`.
