### PR TITLE
Omit the / if a controller name starts with it

### DIFF
--- a/Alloy/lib/alloy.js
+++ b/Alloy/lib/alloy.js
@@ -417,6 +417,7 @@ exports.createWidget = function(id, name, args) {
  * @return {Alloy.Controller} Alloy controller object.
  */
 exports.createController = function(name, args) {
+	name = name.indexOf('/') === 0 ? name.substr(1) : name;
 	return new (require('alloy/controllers/' + name))(args);
 };
 


### PR DESCRIPTION
If a controller name starts with `/` it doesn't work properly, or not at all. It also doesn't throw an error. This change fixes the issue if a controller starts with `/` as it would still make sense to support it.

In this case, both these cases will work the same. Currently the 2nd fails

```js
Alloy.createController('tasks/share');
Alloy.createController('/tasks/share');
```