### PR TITLE
The name of a controller, model or collection doesn't support names with / at start

### DIFF
--- a/Alloy/lib/alloy.js
+++ b/Alloy/lib/alloy.js
@@ -412,11 +412,12 @@ exports.createWidget = function(id, name, args) {
  * @method createController
  * Factory method for instantiating a controller. Creates and returns an instance of the
  * named controller.
- * @param {String} name Name of controller to instantiate.
+ * @param {String} name Name of controller, or relative path to controller to instantiate.
  * @param {Object} [args] Arguments to pass to the controller.
  * @return {Alloy.Controller} Alloy controller object.
  */
 exports.createController = function(name, args) {
+	name = name.indexOf('/') === 0 ? name.substr(1) : name;
 	return new (require('alloy/controllers/' + name))(args);
 };
 
@@ -427,11 +428,12 @@ exports.createController = function(name, args) {
  *
  * See [Backbone.Model](http://docs.appcelerator.com/backbone/0.9.2/#Model) in the Backbone.js documentation for
  * information on the methods and properties provided by the Model object.
- * @param {String} name Name of model to instantiate.
+ * @param {String} name Name of model, or relative path of model to instantiate.
  * @param {Object} [args] Arguments to pass to the model.
  * @return {Backbone.Model} Backbone model object.
  */
 exports.createModel = function(name, args) {
+	name = name.indexOf('/') === 0 ? name.substr(1) : name;
 	return new (require('alloy/models/' + ucfirst(name)).Model)(args);
 };
 
@@ -443,11 +445,12 @@ exports.createModel = function(name, args) {
  * See [Backbone.Collection](http://docs.appcelerator.com/backbone/0.9.2/#Collection) in the Backbone.js
  * documentation for  information on the methods and  properties provided by the
  * Collection object.
- * @param {String} name Name of model to hold in this collection.
+ * @param {String} name Name of model, or relative path of model to hold in this collection.
  * @param {Object} [args] Arguments to pass to the collection.
  * @return {Backbone.Collection} Backbone collection object.
  */
 exports.createCollection = function(name, args) {
+	name = name.indexOf('/') === 0 ? name.substr(1) : name;
 	return new (require('alloy/models/' + ucfirst(name)).Collection)(args);
 };
 


### PR DESCRIPTION
The name of the controller can also be a relative path. But to make it uniform (just like with images) you should be able to add a `/` in front of the name/path. It currently doesn't support that. This fix resolves that for controllers,models and collections, and adds to the documentation it can also be a relative path.

An example why this should be supported is because it is consistent for everything. Image names/paths with a leading `/` on Android is even required, and a controller name/path with a leading `/` is generating errors. This leads to unexpected issues, and confusion. 

This fix makes it consistent:

``` javascript
Alloy.createController('name'); // will work
Alloy.createController('/path/to/controller'); // will also work
$.imageView.image = '/path/to/image.png' // will (only) work
Alloy.createCollection('name'); // will work
Alloy.createCollection('/path/to/collection'); // will work
```

Consistent behaviour across all names/paths leads to expected functionality. Exceptions make it confusion. This PR fixes that
