### PR TITLE
Make input text for Add feature readable on Android

### DIFF
--- a/samples/todo/styles/add.tss
+++ b/samples/todo/styles/add.tss
@@ -7,7 +7,8 @@
 	width: '90%',
 	top: '25dp',
 	borderStyle: Ti.UI.INPUT_BORDERSTYLE_ROUNDED,
-	returnKeyType: Ti.UI.RETURNKEY_DONE
+	returnKeyType: Ti.UI.RETURNKEY_DONE,
+	color: '#000'
 }
 
 ".button":{


### PR DESCRIPTION
Add font color 'black' to #itemField. As of Ti SDK 4.0, you can't read what you are typing into the text field otherwise. Seems to be a problem with only Android.