### PR TITLE
Fixed a style ordering bug

### DIFF
--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -148,14 +148,14 @@ exports.loadGlobalStyles = function(appPath, opts) {
 
 	// see if we can use the cached global style
 	if (buildlog.data.globalStyleCacheHash === hash && fs.existsSync(cacheFile)) {
-
 		// load global style object from cache
 		logger.info('[global style] loading from cache...');
 		exports.globalStyle = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
 		ret = true;
 
+		// increment the style order counter with the number of rules in the global style
+		styleOrderCounter += exports.globalStyle.length;
 	} else {
-
 		// add new hash to the buildlog
 		buildlog.data.globalStyleCacheHash = hash;
 
@@ -174,9 +174,9 @@ exports.loadGlobalStyles = function(appPath, opts) {
 		logger.info('[global style] writing to cache...');
 		fs.writeFileSync(cacheFile, JSON.stringify(exports.globalStyle));
 
+		// simply increment the style order counter
+		styleOrderCounter++;
 	}
-
-	styleOrderCounter++;
 
 	return ret;
 };


### PR DESCRIPTION
This bug is described in [[AC-189]](https://jira.appcelerator.org/browse/AC-189).

In some cases, when the developer overloads in a given stylesheet some styles defined in the `app.tss` global style file, the alloy compilation won't produce the same resulting javascript accross successive compilations.

Alloy's styler orders style rules to define their priority, but there's a bug with the `app.tss` global styles being cached and therefore not correctly being counted by the styler when they're loaded back from cache, during a latter compilation phase when `app.tss` didn't change.

This fix simply correctly increments the styleCounter with the number of rules loaded from the global style cache. Kudos to my colleague @vdesdoigts for spotting the bug and isolating a reproducible symptom.