### PR TITLE
[ALOY-1288] Windows: Label not visible when using default app.tss

### DIFF
--- a/Alloy/template/app.tss
+++ b/Alloy/template/app.tss
@@ -11,16 +11,16 @@ For example, the following would apply to all labels, windows,
 and text fields (depending on platform) in your app unless you
 overrode the settings with other TSS, XML, or JS settings:
 
-'Label[platform=android]': {
-	color: '#000' // all platforms except Android default to black
+'Label[platform=android,windows]': {
+	color: '#000' // all platforms except Android and Windows default to black
 }
 
 'Window': {
-	backgroundColor: '#fff' // white background instead of default transparent
+	backgroundColor: '#fff' // white background instead of default transparent or black
 }
 
 'TextField[platform=android]': {
-	height: Ti.UI.SIZE //
+	height: Ti.UI.SIZE
 }
 
 */


### PR DESCRIPTION
Windows also defaults to white labels, so since we set the Ti.UI.Window backgrounds to white, the label should be black or it will be invisible.

https://jira.appcelerator.org/browse/ALOY-1288