### PR TITLE
[CLI-768] Alloy app fails to build on Windows with error "Alloy compiler failed"

### DIFF
--- a/hooks/alloy.js
+++ b/hooks/alloy.js
@@ -141,7 +141,7 @@ exports.init = function (logger, config, cli, appc) {
 
 				// execute alloy in os-specific manner
 				var child;
-				if (process.platform === 'win32') {
+				if (process.platform === 'win32' && paths.alloy.indexOf('.bin') !== -1) {
 					cmd.shift();
 					logger.info(__('Executing Alloy compile: %s',
 						['cmd','/s','/c'].concat(cmd).join(' ').cyan));

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "mobileweb",
     "appc-client"
   ],
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": "Appcelerator, Inc. <info@appcelerator.com>",
   "maintainers": [
     {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/CLI-768
Dependent: https://github.com/appcelerator/appc-cli-titanium/pull/126