### PR TITLE
[ALOY-1305] deepclean.js syntax error: missing semicolon

### DIFF
--- a/hooks/deepclean.js
+++ b/hooks/deepclean.js
@@ -14,7 +14,7 @@ exports.init = function (logger, config, cli, appc) {
 
 	function run() {
 		if(cli.argv['shallow'] === '') {
-			logger.info('Not cleaning the Resources directory')
+			logger.info('Not cleaning the Resources directory');
 			return;
 		}
 		var appDir = path.join(cli.argv['project-dir'], 'app');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "mobileweb",
     "appc-client"
   ],
-  "version": "1.7.8",
+  "version": "1.7.9",
   "author": "Appcelerator, Inc. <info@appcelerator.com>",
   "maintainers": [
     {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1305