### PR TITLE
moment.lang() example fix

### DIFF
--- a/docs/apidoc/moment.js
+++ b/docs/apidoc/moment.js
@@ -15,7 +15,7 @@
  *     var moment = require('alloy/moment');
  *     require('alloy/moment/lang/de');
  *     require('alloy/moment/lang/fr');
- *     moment.lang(Ti.Locale.currentLocale); // Set current system locale, as a combination of ISO 2-letter language and country codes.
+ *     moment.lang(Ti.Locale.currentLanguage); // Set current system locale, as a combination of ISO 2-letter language.
  * 
  * For documentation, usage examples and more information, see [http://momentjs.com/](http://momentjs.com).
  */


### PR DESCRIPTION
Currently, moment need a 2-letter language to setup it right, so cannot use moment.lang(Ti.Locale.currentLocale) (2 language- 2 country)
Instead, we must use moment.lang(Ti.Locale.currentLanguage) (2 language only)