### PR TITLE
[AC-540] Disable alloy.js template remplacement when alloy selective compilation is used

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -174,17 +174,18 @@ module.exports = function(args, program) {
 		path.join(paths.resources, titaniumFolder, "alloy", "backbone.js")
 	);
 
-	// Generate alloy.js from template
-	var libAlloyJsDest = path.join(paths.resources, titaniumFolder, 'alloy.js');
-	var pkginfo = require('pkginfo')(module, 'version');
-	logger.trace('Generating ' + path.relative(titaniumFolder, libAlloyJsDest).yellow);
-	fs.writeFileSync(
-		libAlloyJsDest,
-		ejs.render(
-			fs.readFileSync(path.join(alloyRoot, 'template', 'lib', 'alloy.js'), 'utf8'),
-			{ version: module.exports.version }
-		)
-	);
+	if (restrictionPath === null || restrictionPath === path.join(paths.app, 'alloy.js')) {
+		// Generate alloy.js from template
+		var libAlloyJsDest = path.join(paths.resources, titaniumFolder, 'alloy.js');
+		logger.trace('Generating ' + path.relative(titaniumFolder, libAlloyJsDest).yellow);
+		fs.writeFileSync(
+			libAlloyJsDest,
+			ejs.render(
+				fs.readFileSync(path.join(alloyRoot, 'template', 'lib', 'alloy.js'), 'utf8'),
+				{ version: module.exports.version }
+			)
+		);
+	}
 
 	updateFilesWithBuildLog(
 		path.join(alloyRoot, 'common'),

--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -177,6 +177,7 @@ module.exports = function(args, program) {
 	if (restrictionPath === null || restrictionPath === path.join(paths.app, 'alloy.js')) {
 		// Generate alloy.js from template
 		var libAlloyJsDest = path.join(paths.resources, titaniumFolder, 'alloy.js');
+		var pkginfo = require('pkginfo')(module, 'version');
 		logger.trace('Generating ' + path.relative(titaniumFolder, libAlloyJsDest).yellow);
 		fs.writeFileSync(
 			libAlloyJsDest,


### PR DESCRIPTION
This PR fixes the JIRA ticket [AC-540](https://jira.appcelerator.org/browse/AC-540).

Since [this commit|https://github.com/feons/alloy/commit](25855c1f342eecf6cb6e69dca007d05ebde1771b#diff-ddbdb7300fa15590afdfee9246ac61fcR177), Alloy's selective compilation is broken since the `Resources`'s `alloy.js` file gets replaced each and every time the alloy compile command is called.

Instead, the fix should look if there's a file restriction, and not replace `alloy.js` if this restriction does not affect this file.

This is particularly problematic when using some compilation watcher (aka. tishadow + grunt-tishadow), which look for changes in the `Resources` folder to re-launch the app. With the current change, the app will be refreshed using a template-based `alloy.js` file (not a recompiled one).