### PR TITLE
Generating `Resources/alloy.js` from template is not required when selective compile

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -174,7 +174,7 @@ module.exports = function(args, program) {
 		path.join(paths.resources, titaniumFolder, "alloy", "backbone.js")
 	);
 
-	if (restrictionPath === null || restrictionPath === path.join(paths.app, 'alloy.js')) {
+	if (restrictionPath === null) {
 		// Generate alloy.js from template
 		var libAlloyJsDest = path.join(paths.resources, titaniumFolder, 'alloy.js');
 		var pkginfo = require('pkginfo')(module, 'version');


### PR DESCRIPTION
When compiling only `app/alloy.js`, generating `Resources/alloy.js` from template is not required.
Because `Resource/alloy.js` is not user's code but builtin code. So when compiling specific controller and alloy.js only, Generate `Resource/alloy.js` should be skipped.

Current version of alloy(1.7.32) has a problem related with this issue.

Reproduce steps

1. delete all file of `Resources` folder.
1. run : `alloy compile -q ios --config file=app/alloy.js`
1. you can check compiling result on `Resource`
1. `Resources/iphone/alloy.js` is generated from template 
1. But `Resources/iphone/alloy.js` is not optimized. It has uncompiled CONSTANT such as `OS_MOBILEWEB`. it makses `undefined` error on runtime.

