### PR TITLE
[ALOY-1355] Fixed issue where attributes containing 'true' or 'false'…

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -225,6 +225,11 @@ exports.getParserArgs = function(node, state, opts) {
 					createArgs[CONST.CLASS_PROPERTY] = theValue.split(/\s+/) || [];
 				}
 			} else {
+				if (theValue === 'true') {
+					theValue = true;
+				} else if (theValue === 'false') {
+					theValue = false;
+				}
 				createArgs[attrName] = theValue;
 			}
 		}

--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -229,6 +229,16 @@ exports.getParserArgs = function(node, state, opts) {
 					theValue = true;
 				} else if (theValue === 'false') {
 					theValue = false;
+				} else {
+					var n = parseInt(theValue);
+					if (!isNaN(n) && String(n) === theValue.trim()) {
+						theValue = n;
+					} else {
+						n = parseFloat(theValue);
+						if (!isNaN(n) && String(n) === theValue.trim()) {
+							theValue = n;
+						}
+					}
 				}
 				createArgs[attrName] = theValue;
 			}


### PR DESCRIPTION
… where being treated as strings instead of booleans. There's no way for Alloy to know if the attribute really is a boolean or not, so we have to blindly test for 'true' and 'false'. This isn't ideal. If someone has a label of 'true', then it will be cast as a bool, but *should* be cast back to a string when used in the context of a string value.