### PR TITLE
Added check for variable existence before calling off in destroy function

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -986,7 +986,7 @@ exports.generateCollectionBindingTemplate = function(args) {
 	code += "};";
 	code += colVar + ".on('" + CONST.COLLECTION_BINDING_EVENTS + "'," + handlerFunc + ");";
 
-	exports.destroyCode += ((args.parentFormFactor) ? 'Alloy.is' + U.ucfirst(args.parentFormFactor) + ' && ' : '' ) +
+	exports.destroyCode += colVar + " && " + ((args.parentFormFactor) ? 'Alloy.is' + U.ucfirst(args.parentFormFactor) + ' && ' : '' ) +
 		colVar + ".off('" + CONST.COLLECTION_BINDING_EVENTS + "'," + handlerFunc + ");";
 
 	return code;

--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -720,7 +720,7 @@ function parseAlloyComponent(view, dir, manifest, noView, fileRestriction) {
 		// open the model binding handler
 		var handlerVar = CU.generateUniqueId();
 		template.viewCode += 'var ' + handlerVar + '=function() {';
-		CU.destroyCode += ((state.parentFormFactor) ? 'is' + U.ucfirst(state.parentFormFactor) : '' ) +
+		CU.destroyCode += modelVar + " && " + ((state.parentFormFactor) ? 'is' + U.ucfirst(state.parentFormFactor) : '' ) +
 			modelVar + ".off('" + CONST.MODEL_BINDING_EVENTS + "'," + handlerVar + ");";
 
 		// for each specific conditional within the bindings map....


### PR DESCRIPTION
If you have an Alloy component that uses databinding and has conditional code defined in the xml, the destroy function is not taking into consideration the fact that the component may be undefined before calling the `off` function.