### PR TITLE
Ensure style is a date before calling createDate

### DIFF
--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -360,9 +360,10 @@ exports.processStyle = function(_style, _state) {
 					code += prefix + matches[1] + ','; // matched a JS expression
 				} else {
 					if(typeof style.type !== 'undefined' && typeof style.type.indexOf === 'function' && (style.type).indexOf('UI.PICKER') !== -1 && value !== 'picker') {
-						// ALOY-263, support date/time style pickers
-						var d = U.createDate(value);
 						if(DATEFIELDS.indexOf(sn) !== -1) {
+							// ALOY-263, support date/time style pickers
+							var d = U.createDate(value);
+
 							if(U.isValidDate(d, sn)) {
 								code += prefix + 'new Date("'+d.toString()+'"),';
 							}


### PR DESCRIPTION
Note: tests were failing before any changes were made. I did not look at fixing those tests

Fixes

[WARN]  ing: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.
[ERROR]
[DEBUG]     at Function.createFromInputFallback (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:746:36)
[DEBUG]     at configFromString (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:826:32)
[DEBUG]     at configFromInput (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:1353:13)
[DEBUG]     at prepareConfig (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:1340:13)
[DEBUG]     at createFromConfig (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:1307:44)
[DEBUG]     at createLocalOrUTC (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:1385:16)
[DEBUG]     at local__createLocal (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:1389:16)
[DEBUG]     at utils_hooks__hooks (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/node_modules/moment/moment.js:16:29)
[DEBUG]     at Object.exports.createDate (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/utils.js:575:26)
[DEBUG]     at processStyle (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/styler.js:367:17)
[DEBUG]     at Object.exports.processStyle (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/styler.js:423:2)
[DEBUG]     at Object.exports.generateStyleParams (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/styler.js:603:20)
[DEBUG]     at parse (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/parsers/default.js:132:19)
[DEBUG]     at Object.exports.parse (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/parsers/base.js:11:17)
[DEBUG]     at Object.exports.parse (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/parsers/default.js:10:27)
[DEBUG]     at parse (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/parsers/Ti.UI.Picker.js:81:31)
[DEBUG]     at Object.exports.parse (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/parsers/base.js:11:17)
[DEBUG]     at Object.exports.parse (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/parsers/Ti.UI.Picker.js:29:27)
[DEBUG]     at Object.exports.generateNode (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:332:48)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:416:29
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at Object.exports.generateNode (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:407:5)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:416:29
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at Object.exports.generateNode (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:407:5)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:416:29
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at Object.exports.generateNode (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:407:5)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:416:29
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at Object.exports.generateNode (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:407:5)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:416:29
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at Object.exports.generateNode (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/compilerUtils.js:407:5)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/index.js:693:28
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at parseAlloyComponent (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/index.js:687:5)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/index.js:304:6
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at /Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/index.js:293:6
[DEBUG]     at Array.forEach (native)
[DEBUG]     at Function._.each._.forEach (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/lib/alloy/underscore.js:79:11)
[DEBUG]     at module.exports (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/commands/compile/index.js:289:4)
[DEBUG]     at Object.<anonymous> (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/Alloy/alloy.js:113:46)
[DEBUG]     at Module._compile (module.js:410:26)
[DEBUG]     at Object.Module._extensions..js (module.js:417:10)
[DEBUG]     at Module.load (module.js:344:32)
[DEBUG]     at Function.Module._load (module.js:301:12)
[DEBUG]     at Module.require (module.js:354:17)
[DEBUG]     at require (internal/module.js:12:17)
[DEBUG]     at Object.<anonymous> (/Users/cgedrim/.nvm/versions/node/v4.2.6/lib/node_modules/alloy/bin/alloy:3:1)
[DEBUG]     at Module._compile (module.js:410:26)
[DEBUG]     at Object.Module._extensions..js (module.js:417:10)
[DEBUG]     at Module.load (module.js:344:32)
[DEBUG]     at Function.Module._load (module.js:301:12)
[DEBUG]     at Function.Module.runMain (module.js:442:10)
[DEBUG]     at startup (node.js:136:18)
[DEBUG]     at node.js:966:3