### PR TITLE
[TIMOB-20577] Fix getField context for Windows

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -224,7 +224,7 @@ function Sync(method, model, opts) {
 			var values = [];
 			var fieldNames = [];
 			var fieldCount = _.isFunction(rs.fieldCount) ? rs.fieldCount() : rs.fieldCount;
-			var getField = OS_ANDROID ? rs.field.bind(rs) : rs.field;
+			var getField = OS_ANDROID || OS_WINDOWS ? rs.field.bind(rs) : rs.field;
 			var i = 0;
 
 			for (; i < fieldCount; i++) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "mobileweb",
     "appc-client"
   ],
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": "Appcelerator, Inc. <info@appcelerator.com>",
   "maintainers": [
     {


### PR DESCRIPTION
- Bind the ```ResultSet``` context to the ```field``` call to prevent an invalid pointer

###### TEST CASE
```Javascript
var booksDB = Ti.Database.open('booksDB');
booksDB.execute('CREATE TABLE IF NOT EXISTS books(id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, author TEXT)');
booksDB.execute('REPLACE INTO books (title,author) VALUES (?,?)', ('Great Expectations', 'Charles Dickens'));
var result = booksDB.execute('SELECT * FROM books'),
    getField = result.field; // INVALID
    // getField = result.field.bind(result); // VALID
Ti.API.info('=== RESULT ===');
Ti.API.info('fieldCount: ' + result.fieldCount);
for (var i = 0, j = result.fieldCount; i < j; i++) {
    Ti.API.info(getField(i));
}
Ti.API.info('==============');
result.close();
booksDB.close();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20577)