### PR TITLE
[TIMOB-20085] "ti clean" does not scan SDK hooks

### DIFF
--- a/hooks/deepclean.js
+++ b/hooks/deepclean.js
@@ -12,9 +12,10 @@ exports.init = function (logger, config, cli, appc) {
 		fs = require('fs'),
 		afs = appc.fs;
 
-	function run() {
+	function run(finished) {
 		if(cli.argv['shallow'] === '') {
 			logger.info('Not cleaning the Resources directory');
+			finished();
 			return;
 		}
 		var appDir = path.join(cli.argv['project-dir'], 'app');
@@ -27,14 +28,16 @@ exports.init = function (logger, config, cli, appc) {
 		var resourcesDir = path.join(cli.argv['project-dir'], 'Resources');
 		if (!afs.exists(resourcesDir)) {
 			logger.debug('Resources directory does not exist.');
+			finished();
 			return;
 		}
 		rmdir(resourcesDir, fs, path, logger);
 		logger.debug('Resources directory of %s has been emptied', appDir.cyan);
+		finished();
 	}
 
 	cli.addHook('clean.post', function (build, finished) {
-		run();
+		run(finished);
 	});
 
 };


### PR DESCRIPTION
Related to [TIMOB-20085](https://jira.appcelerator.org/browse/TIMOB-20085) and https://github.com/appcelerator/titanium_mobile/pull/7628

[hooks/deepclean.js](https://github.com/appcelerator/alloy/blob/master/hooks/deepclean.js) prevents from running SDK-specific `ti clean` hook because `deepclean.js` doesn't properly call finish callback.
