### PR TITLE
support multiple restrict files

### DIFF
--- a/Alloy/utils.js
+++ b/Alloy/utils.js
@@ -203,7 +203,7 @@ exports.updateFiles = function(srcDir, dstDir, opts) {
 		if (!fs.existsSync(src) ||
 			(opts.filter && opts.filter.test(file)) ||
 			(opts.exceptions && _.contains(opts.exceptions, file)) ||
-			(opts.restrictionPath && src !== opts.restrictionPath)) {
+			(opts.restrictionPath &&  !_.contains(opts.restrictionPath,src)) ) {
 			return;
 		}
 


### PR DESCRIPTION
#625 is a PR to allow compile only one specific file.
This PR supports compiling several specific files.

example:

```shell
# file=view1.js,file=view2.js,file=view3.js ...

alloy compile --config platform=ios,file=app/controllers/index.js,file=app/controller/myCtrl.js
```
