### PR TITLE
add 'skipOptimize' option to alloy compile config

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -446,6 +446,8 @@ module.exports = function(args, program) {
 
 	if (restrictionSkipOptimize) {
 		logger.info('Skipping optimize due to file restriction.');
+	} if (alloyConfig.skipOptimize){
+		logger.info('Skipping optimize due to alloy config setting.');
 	} else {
 		optimizeCompiledCode(alloyConfig, paths);
 	}

--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -446,7 +446,7 @@ module.exports = function(args, program) {
 
 	if (restrictionSkipOptimize) {
 		logger.info('Skipping optimize due to file restriction.');
-	} if (alloyConfig.skipOptimize){
+	} else if (alloyConfig.skipOptimize){
 		logger.info('Skipping optimize due to alloy config setting.');
 	} else {
 		optimizeCompiledCode(alloyConfig, paths);


### PR DESCRIPTION
## Problem
When alloy compiling, all js files be optimized.
If you project has many js lib, optimizing take quite long time.

## Solution
This PR make you can skip js file optimizing manually.
If you want to skip optimization when you alloy compile, add `skipOptimize=true` option to alloy config:
```
alloy compile --config platform=ios,skipOptimize=true
```

You can save time using this options.

On my MBP,
Alloy compiling of default alloy project took 0.9s without skipOptimize.
But it took 0.3s with skipOptimize. 👍 