### PR TITLE
[ALOY-1535] Remove unnecessary warning message with iOS

### DIFF
--- a/Alloy/commands/compile/parsers/Alloy.Abstract._ItemContainer.js
+++ b/Alloy/commands/compile/parsers/Alloy.Abstract._ItemContainer.js
@@ -71,8 +71,17 @@ function parse(node, state, args) {
 						}
 					});
 					code += androidView;
-				} else if (theNode) {
-					logger.warn('Additional views in ' + theNode + ' only supported on Android');
+				} else if (child.getAttribute('platform') !== 'android') {
+					var currentPlatform =  child.getAttribute('platform');
+					var warningLog = [
+						'Additional views in <' + node.nodeName + '> (line ' + node.lineNumber + ') are only supported on Android',
+					];
+					if (!currentPlatform) {
+						warningLog.push('To get rid of this warning, add platform="android" to your child elements');
+					} else {
+						warningLog.push('To get rid of this warning, remove any other platforms from your child elements');
+					}
+					logger.warn(warningLog);
 				}
 			} else {
 				U.die(theNode + ' can only have one androidView');

--- a/Alloy/commands/compile/parsers/Alloy.Abstract._ItemContainer.js
+++ b/Alloy/commands/compile/parsers/Alloy.Abstract._ItemContainer.js
@@ -71,7 +71,7 @@ function parse(node, state, args) {
 						}
 					});
 					code += androidView;
-				} else {
+				} else if (theNode) {
 					logger.warn('Additional views in ' + theNode + ' only supported on Android');
 				}
 			} else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixes
 
+* [ALOY-1535](https://jira.appcelerator.org/browse/ALOY-1535) Only warn when using an AlertDialog with child views not restricted to Android
+
 ### Release 1.13.9
 
 #### Fixes


### PR DESCRIPTION
On iOS compiling we get warning `Additional views in null only supported on Android` with code
```xml
<AlertDialog id="confirmAlertDialog">
    <View platform="android">
        <Label>Android only!!</Label>
    </View>
</AlertDialog>
```