### PR TITLE
Add optimizingExeptions option to config.json

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -1107,7 +1107,8 @@ function optimizeCompiledCode(alloyConfig, paths) {
 			'alloy/constants.js',
 			'alloy/underscore.js',
 			'alloy/widget.js'
-		];
+		].concat(compileConfig.optimizingExceptions || []);
+
 		_.each(exceptions.slice(0), function(ex) {
 			exceptions.push(path.join(titaniumFolder, ex));
 		});


### PR DESCRIPTION
This PR make you can skip the file when doing an optimization manually.
There are no reason to optimize js files which doesn't depends on alloy.

If you want to skip, add `optimizingExeptions` to `config.json`:
- If `app/lib/q.js`, the path should be `q.js`(see below. After compiling, `app/lib/q.js` to `q.js`)

```javascript
{
  //...
  "optimizingExceptions": [
        "moment2.11.1.js",
        "q.js",
        "underscore1.8.3.js",
        "sf.js",
        "nl.fokkezb.html2as.js"
    ],
  //...
}
```