### PR TITLE
[AC-4875] Update gitignore

### DIFF
--- a/Alloy/template/gitignore.txt
+++ b/Alloy/template/gitignore.txt
@@ -1,5 +1,7 @@
 .DS_Store
-Resources
+/Resources
+/platform
+/i18n
 build.log
 build
 npm-debug.log


### PR DESCRIPTION
JIRA-Ticket: https://jira.appcelerator.org/browse/AC-4875

```
ti create -t app -n test --id com.test.test -p all -u test.de -d .
cd test
alloy new
```
still had an old gitignore without the /platform and /i18n (like in https://github.com/appcelerator/alloy/blob/master/templates/default/.gitignore)