### PR TITLE
[ALOY-1263] Enable strict mode in controller

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -571,7 +571,8 @@ function parseAlloyComponent(view, dir, manifest, noView, fileRestriction) {
 				fs.readFileSync(path.join(alloyRoot, 'template', 'wpath.js'), 'utf8'),
 				{ WIDGETID: manifest.id }
 			),
-			__MAPMARKER_CONTROLLER_CODE__: ''
+			__MAPMARKER_CONTROLLER_CODE__: '',
+			useStrict: compileConfig.strict ? '"use strict";' : ''
 		},
 		widgetDir = dirname ? path.join(CONST.DIR.COMPONENT, dirname) : CONST.DIR.COMPONENT,
 		widgetStyleDir = dirname ? path.join(CONST.DIR.RUNTIME_STYLE, dirname) :
@@ -1048,7 +1049,8 @@ function processModels(dirs) {
 			var code = _.template(fs.readFileSync(modelTemplateFile, 'utf8'), {
 				basename: basename,
 				modelJs: fs.readFileSync(fullpath, 'utf8'),
-				migrations: findModelMigrations(basename, migrationDir)
+				migrations: findModelMigrations(basename, migrationDir),
+				useStrict: compileConfig.strict ? '"use strict";' : ''
 			});
 
 			// write the model to the runtime file
@@ -1109,12 +1111,12 @@ function optimizeCompiledCode(alloyConfig, paths) {
 			'alloy/widget.js',
 			'node_modules'
 		].concat(compileConfig.optimizingExceptions || []);
-		
+
 		// widget controllers are already optimized. It should be listed in exceptions.
 		_.each(compileConfig.dependencies, function (version, widgetName) {
 			exceptions.push('alloy/widgets/' + widgetName + '/controllers/');
 		});
-		
+
 		_.each(exceptions.slice(0), function(ex) {
 			exceptions.push(path.join(titaniumFolder, ex));
 		});

--- a/Alloy/common/constants.js
+++ b/Alloy/common/constants.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var isTitanium = typeof Titanium !== 'undefined';
 var _, generatePlatformArray;
 

--- a/Alloy/lib/alloy/controllers/BaseController.js
+++ b/Alloy/lib/alloy/controllers/BaseController.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Alloy = require('/alloy'),
 	Backbone = Alloy.Backbone,
 	_ = Alloy._;

--- a/Alloy/lib/alloy/sync/localStorage.js
+++ b/Alloy/lib/alloy/sync/localStorage.js
@@ -1,6 +1,8 @@
 /*
  * HTML5 localStorage sync adapter
  */
+'use strict';
+
 var _ = require('/alloy/underscore')._;
 
 function S4() {

--- a/Alloy/lib/alloy/sync/properties.js
+++ b/Alloy/lib/alloy/sync/properties.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Alloy = require('/alloy'),
 	_ = require('/alloy/underscore')._,
 	TAP = Ti.App.Properties;

--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('/alloy/underscore')._,
 	backbone = require('/alloy/backbone');
 

--- a/Alloy/lib/alloy/widget.js
+++ b/Alloy/lib/alloy/widget.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Alloy = require('/alloy');
 
 // Hold a collection of widget objects instances. These

--- a/Alloy/template/alloy.js
+++ b/Alloy/template/alloy.js
@@ -9,3 +9,5 @@
 // object. For example:
 //
 // Alloy.Globals.someGlobalFunction = function(){};
+
+'use strict';

--- a/Alloy/template/component.js
+++ b/Alloy/template/component.js
@@ -1,3 +1,5 @@
+<%= useStrict %>
+
 var Alloy = require('/alloy'),
 	Backbone = Alloy.Backbone,
 	_ = Alloy._;

--- a/Alloy/template/config.json
+++ b/Alloy/template/config.json
@@ -8,5 +8,6 @@
 	"os:ios": {},
 	"os:mobileweb": {},
 	"os:windows": {},
-	"dependencies": {}
+	"dependencies": {},
+	"strict": true
 }

--- a/Alloy/template/lib/alloy.js
+++ b/Alloy/template/lib/alloy.js
@@ -23,6 +23,9 @@
  * For guides on using Alloy, see
  * [Alloy Framework](http://docs.appcelerator.com/platform/latest/#!/guide/Alloy_Framework).
  */
+
+'use strict';
+
 var _ = require('/alloy/underscore')._,
 	Backbone = require('/alloy/backbone'),
 	CONST = require('/alloy/constants');

--- a/Alloy/template/model.js
+++ b/Alloy/template/model.js
@@ -1,3 +1,5 @@
+<%= useStrict %>
+
 var Alloy = require('/alloy'),
     _ = require("/alloy/underscore")._,
 	model, collection;


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1263

Enabling this in new projects is easy, enforcing this on an existing project might require a bit more work from developers depending on how sloppy the controllers are.

To opt into strict mode, add `"strict": true` in `config.json`.