### PR TITLE
Add babel-preset-es2015

### DIFF
--- a/Alloy/commands/compile/sourceMapper.js
+++ b/Alloy/commands/compile/sourceMapper.js
@@ -24,7 +24,7 @@ exports.OPTIONS_OUTPUT = {
 	comments: false,
 	babelrc: false,
 	passPerPreset: false,
-	presets: ['es2015']
+	presets: [require('babel-preset-es2015')]
 };
 
 function mapLine(mapper, theMap, genMap, line) {

--- a/Alloy/commands/compile/sourceMapper.js
+++ b/Alloy/commands/compile/sourceMapper.js
@@ -23,7 +23,8 @@ exports.OPTIONS_OUTPUT = {
 	compact: false,
 	comments: false,
 	babelrc: false,
-	passPerPreset: false
+	passPerPreset: false,
+	presets: ['es2015']
 };
 
 function mapLine(mapper, theMap, genMap, line) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "async": "^2.4.0",
     "babel-core": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
     "babel-traverse": "^6.23.1",
     "babel-types": "^6.23.0",
     "babylon": "^6.16.1",


### PR DESCRIPTION
I am really happy to be babel applied to the alloy.

Thank you very much to @sgtcoolguy.

I think ES2015 (ex: arrow functions, const, let) are already used as standard, so we need es2015 preset.

Thank you.