### PR TITLE
[ALOY-1570] Alloy: exports.baseController does not work since 1.10.0 (Regression)

### DIFF
--- a/Alloy/commands/compile/ast/controller.js
+++ b/Alloy/commands/compile/ast/controller.js
@@ -3,7 +3,7 @@ var U = require('../../../utils'),
 	types = require('babel-types'),
 	traverse = require('babel-traverse').default;
 
-var isBaseControllerExportExpression = types.buildMatchMemberExpression('export.baseController');
+var isBaseControllerExportExpression = types.buildMatchMemberExpression('exports.baseController');
 
 exports.getBaseController = function(code, file) {
 	var baseController = '';

--- a/Alloy/commands/compile/ast/controller.js
+++ b/Alloy/commands/compile/ast/controller.js
@@ -14,7 +14,7 @@ exports.getBaseController = function(code, file) {
 			enter: function(path) {
 				if (types.isAssignmentExpression(path.node) && isBaseControllerExportExpression(path.node.left)) {
 					// what's equivalent of print_to_string()? I replaced with simple value property assuming it's a string literal
-					baseController = path.node.right.value;
+					baseController = '\'' + path.node.right.value + '\'';
 				}
 			}
 		});


### PR DESCRIPTION
*JIRA* https://jira.appcelerator.org/browse/ALOY-1570

*Description*
This is a typo when I converted the code from Uglify to Babel. It used to look for `exports.baseController` and I fudged the translation to be `export.baseController`.