### PR TITLE
[ALOY-1582] Fix Ti.Platform.osname on Windows

### DIFF
--- a/platforms/windows/index.js
+++ b/platforms/windows/index.js
@@ -3,5 +3,5 @@ module.exports = new (require('../base.js'))({
 	alloyFolder: 'windows',
 	titaniumFolder: 'windows',
 	name: 'Windows Phone',
-	osname: 'windows'
+	osname: ['windowsphone', 'windowsstore']
 });


### PR DESCRIPTION
JIRA:  https://jira.appcelerator.org/browse/ALOY-1582

`Ti.Platform.osname` should report windowsstore when target is ws-local, and windowsphone when target is wp-emulator/wp-device