### PR TITLE
[TIMOB-25397] Fallback if empty ResultSet is returned

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -422,7 +422,8 @@ function installDatabase(config) {
 			rs.next();
 		}
 		rs.close();
-	} else {
+	}
+	if (Object.keys(columns).length === 0) {
 		var idAttribute = (config.adapter.idAttribute) ? config.adapter.idAttribute : ALLOY_ID_DEFAULT;
 		for (var k in config.columns) {
 			cName = k;


### PR DESCRIPTION
- In the event `db.execute()` returns no results, fallback to obtain `columns`
- This PR replaces the solution here: https://github.com/appcelerator/titanium_mobile/pull/9527

###### TEST CASE
- Android 8.0 / iOS 11
- Follow the test case [here](https://jira.appcelerator.org/browse/TIMOB-20222)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25397)