### PR TITLE
[ALOY-1602] Avoid some global variables to be only available in parent controller.

### DIFF
--- a/Alloy/template/component.js
+++ b/Alloy/template/component.js
@@ -9,7 +9,6 @@ function __processArg(obj, key) {
 	var arg = null;
 	if (obj) {
 		arg = obj[key] || null;
-		delete obj[key];
 	}
 	return arg;
 }


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/ALOY-1602

I don't understand why it is necessary to remove `$model`, `__parentSymbol` or `__itemTemplate` from the `arguments` variable.

This is causing issues when passing `$model` for example to a controller which is inheriting from another controller as per [Alloy Controller Inheritance documentation](http://docs.appcelerator.com/platform/latest/#!/guide/Alloy_Controllers-section-src-34636384_AlloyControllers-Inheritance).

If we delete it from there, only the parent will have `$model` properly set but the child controller won't as it's deleted from `arguments`.

Another option would be to run `__processArg()` before calling the parent controller but this would mean only the child controller has `$model` properly set, it will be `null` for the parent one.

In order to reproduce:
`index.js`
```js
Alloy.createController('child', { $model: aBackboneModelObject });
```
`parent.js`
```js
console.log(_.isNull($model)); // always return false
...
```
`child.js`
```js
exports.baseController = "parent";
console.log(_.isNull($model)); // always return true
```