### PR TITLE
[TISTUD-8942] Android Debugger: Some breakpoints not hit if "Resume" is done anytime during debug

### DIFF
--- a/Alloy/commands/compile/sourceMapper.js
+++ b/Alloy/commands/compile/sourceMapper.js
@@ -105,9 +105,12 @@ exports.generateCodeAndSourceMap = function(generator, compileConfig) {
 		]
 	});
 	if (compileConfig.sourcemap) {
-		options.sourceMaps = true;
-		options.sourceMapTarget = target.filename;
-		options.inputSourceMap = mapper.toJSON();
+		options.retainLines = true;
+		// FIXME: babel source map generation is broken! So we copy the source map we generated initially
+		// And we tell babel to retain the lines so they stay correct (columns go wacky, but OH WELL)
+		// options.sourceMaps = true;
+		// options.sourceMapTarget = target.filename;
+		// options.inputSourceMap = mapper.toJSON();
 	}
 	var outputResult = babel.transformFromAst(ast, genMap.code, options);
 
@@ -126,8 +129,10 @@ exports.generateCodeAndSourceMap = function(generator, compileConfig) {
 		relativeOutfile = path.relative(compileConfig.dir.project, outfile);
 		fs.mkdirpSync(path.dirname(outfile));
 		chmodr.sync(path.dirname(outfile), 0755);
-		fs.writeFileSync(outfile, JSON.stringify(outputResult.map));
-		logger.debug('  map:        "' + relativeOutfile + '"');
+		fs.writeFileSync(outfile, JSON.stringify(mapper.toJSON()));
+		// FIXME: babel source map generation is broken! So we copy teh source map we generated initially
+		// fs.writeFileSync(outfile, JSON.stringify(outputResult.map));
+		// logger.debug('  map:        "' + relativeOutfile + '"');
 	}
 };
 
@@ -186,9 +191,11 @@ exports.generateSourceMap = function(generator, compileConfig) {
 			[require('./ast/builtins-plugin'), compileConfig],
 			[require('./ast/optimizer-plugin'), compileConfig.alloyConfig]
 		],
-		sourceMaps: true,
-		sourceMapTarget: compiledFileName,
-		inputSourceMap: mapper.toJSON()
+		retainLines: true,
+		// FIXME: babel source map generation is broken! So we copy the source map we generated initially
+		// sourceMaps: true,
+		// sourceMapTarget: compiledFileName,
+		// inputSourceMap: mapper.toJSON()
 	});
 	var outputResult = babel.transformFromAst(ast, genMap.code, options);
 
@@ -198,9 +205,11 @@ exports.generateSourceMap = function(generator, compileConfig) {
 	var outfile = path.join(mapDir, relativeOutfile, path.basename(target.filename)) + '.' + CONST.FILE_EXT.MAP;
 	fs.mkdirpSync(path.dirname(outfile));
 	chmodr.sync(path.dirname(outfile), 0755);
-	var tmp = outputResult.map;
-	tmp.sources[0] = compiledFileName;
-	tmp.sources[1] = origFileName;
-	fs.writeFileSync(outfile, JSON.stringify(tmp));
+	// FIXME: babel source map generation is broken! So we copy the source map we generated initially
+	fs.writeFileSync(outfile, JSON.stringify(mapper.toJSON()));
+	// var tmp = outputResult.map;
+	// tmp.sources[0] = compiledFileName;
+	// tmp.sources[1] = origFileName;
+	// fs.writeFileSync(outfile, JSON.stringify(tmp));
 	logger.debug('  map:        "' + outfile + '"');
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,11 +48,6 @@
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -1507,12 +1502,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.9.tgz",
-      "integrity": "sha1-JQIk5OnvfpH0ytdsrnFLkPYhhZk=",
-      "requires": {
-        "amdefine": "1.0.1"
-      }
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.4.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
@@ -367,9 +367,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
     },
     "core-js": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node.extend": "1.0.10",
     "pkginfo": "0.2.2",
     "resolve": "^1.1.7",
-    "source-map": "0.1.9",
+    "source-map": "^0.6.1",
     "walk-sync": "^0.3.2",
     "xml2tss": "0.0.5",
     "xmldom": "0.1.19"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "preferGlobal": true,
   "dependencies": {
     "async": "^2.4.0",
-    "babel-core": "^6.24.1",
+    "babel-core": "^6.26.0",
     "babel-generator": "^6.26.0",
     "babel-traverse": "^6.23.1",
     "babel-types": "^6.23.0",


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TISTUD-8942

**Description**
This boiled down to "some breakpoints were never honored in alloy apps".

After a lot of digging to isolate where the root cause was, I was able to validate the the debugger/SDK seemed fine, as a built alloy app could be debugged not he generated sources just fine.
Classic apps were OK, so it had to be alloy-specific.

I then dug into alloy's source mapping, since it's really a two-pass operation. First, we generate an initial file and our own source map. Then we hand that off to babel and it's supposed to transform the file more and generate the final source mapping. Great, right? Except babel produces intermittently invalid source maps: babel/babel#6008

The workaround here is to avoid trying to feed source maps to babel or consume the ones they generate, but to have it "retainLines" so our original source map is still correct/valid for line mappings (it may get wonky with columns, but Studio is incapable of handling sub-line precision right now anyways).