### PR TITLE
Correct appc-cli job name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,8 +74,8 @@ timestamps() {
 				stage('Publish') {
 					if (!isPR) {
 						sh 'npm publish'
-						// Trigger appc-cli-wrapper job
-						build job: 'appc-cli-wrapper', wait: false
+						// Trigger appc-cli job
+						build job: '../appc-cli/master', wait: false
 					}
 				}
 


### PR DESCRIPTION
Jenkins job has been failing for a while as it cant find appc-cli-wrapper, based off other projects I believe this is now the job we should be triggering. It might make more sense to also move to buildNPMPackage from pipeline-library