### PR TITLE
[ALOY-1609] Add plugins/ti.alloy to gitignore

### DIFF
--- a/Alloy/template/gitignore.txt
+++ b/Alloy/template/gitignore.txt
@@ -10,3 +10,4 @@ tmp
 .project
 .settings
 Thumbs.db
+plugins/ti.alloy/hooks/alloy.js

--- a/Alloy/template/gitignore.txt
+++ b/Alloy/template/gitignore.txt
@@ -10,4 +10,4 @@ tmp
 .project
 .settings
 Thumbs.db
-plugins/ti.alloy/hooks/alloy.js
+plugins/ti.alloy

--- a/templates/default/.gitignore
+++ b/templates/default/.gitignore
@@ -10,3 +10,4 @@ tmp
 .project
 .settings
 Thumbs.db
+plugins/ti.alloy/hooks/alloy.js

--- a/templates/default/.gitignore
+++ b/templates/default/.gitignore
@@ -10,4 +10,4 @@ tmp
 .project
 .settings
 Thumbs.db
-plugins/ti.alloy/hooks/alloy.js
+plugins/ti.alloy

--- a/templates/two_tabbed/.gitignore
+++ b/templates/two_tabbed/.gitignore
@@ -10,3 +10,4 @@ tmp
 .project
 .settings
 Thumbs.db
+plugins/ti.alloy/hooks/alloy.js

--- a/templates/two_tabbed/.gitignore
+++ b/templates/two_tabbed/.gitignore
@@ -10,4 +10,4 @@ tmp
 .project
 .settings
 Thumbs.db
-plugins/ti.alloy/hooks/alloy.js
+plugins/ti.alloy


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/ALOY-1609

Every time the alloy version changes, the alloy.js plugin file inside the plugin folder changes too. This pollutes git and a default procedure is to remove the file from git alltogether.
