### PR TITLE
[ALOY-1316] Support use of $.args.* in any XML attribute or TSS property

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -212,7 +212,7 @@ exports.getParserArgs = function(node, state, opts) {
 			});
 		} else {
 			var theValue = node.getAttribute(attrName);
-			if (/(^|\+)\s*(?:(?:Ti|Titanium|Alloy.Globals|Alloy.CFG)\.|L\(.+\)\s*$)/.test(theValue)) {
+			if (/(^|\+)\s*(?:(?:Ti|Titanium|Alloy.Globals|Alloy.CFG|\$.args)\.|L\(.+\)\s*$)/.test(theValue)) {
 				var match = theValue.match(/^\s*L\([^'"]+\)\s*$/);
 				if (match !== null) {
 					theValue = theValue.replace(/\(/g, '("').replace(/\)/g, '")');

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -525,11 +525,6 @@ exports.generateStyleParams = function(styles, classes, id, apiName, extraStyle,
 
 	// add in any final styles
 	_.extend(lastObj, extraStyle || {});
-	_.each(lastObj, (v, k) => {
-		if (_.isString(v) && v.indexOf('$.args.') === 0) {
-			lastObj[k] = STYLE_EXPR_PREFIX + v;
-		}
-	});
 
 	if (!_.isEmpty(lastObj)) { styleCollection.push({style:lastObj}); }
 

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -525,6 +525,12 @@ exports.generateStyleParams = function(styles, classes, id, apiName, extraStyle,
 
 	// add in any final styles
 	_.extend(lastObj, extraStyle || {});
+	_.each(lastObj, (v, k) => {
+		if (_.isString(v) && v.indexOf('$.args.') === 0) {
+			lastObj[k] = STYLE_EXPR_PREFIX + v;
+		}
+	});
+
 	if (!_.isEmpty(lastObj)) { styleCollection.push({style:lastObj}); }
 
 	// substitutions for binding

--- a/Alloy/grammar/tss.js
+++ b/Alloy/grammar/tss.js
@@ -47,6 +47,7 @@ module.exports = (function(){
         "elements": parse_elements,
         "value": parse_value,
         "basevalue": parse_basevalue,
+        "DollarArgs": parse_DollarArgs,
         "bitwise_operator": parse_bitwise_operator,
         "OpenParen": parse_OpenParen,
         "CloseParen": parse_CloseParen,
@@ -1072,6 +1073,9 @@ module.exports = (function(){
                             if (result0 === null) {
                               pos = pos0;
                             }
+                            if (result0 === null) {
+                              result0 = parse_DollarArgs();
+                            }
                           }
                         }
                       }
@@ -1081,6 +1085,100 @@ module.exports = (function(){
               }
             }
           }
+        }
+        return result0;
+      }
+      
+      function parse_DollarArgs() {
+        var result0, result1, result2, result3;
+        var pos0, pos1, pos2;
+        
+        pos0 = pos;
+        pos1 = pos;
+        if (input.substr(pos, 6) === "$.args") {
+          result0 = "$.args";
+          pos += 6;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"$.args\"");
+          }
+        }
+        if (result0 !== null) {
+          pos2 = pos;
+          if (input.charCodeAt(pos) === 46) {
+            result2 = ".";
+            pos++;
+          } else {
+            result2 = null;
+            if (reportFailures === 0) {
+              matchFailed("\".\"");
+            }
+          }
+          if (result2 !== null) {
+            result3 = parse_bareString();
+            if (result3 !== null) {
+              result2 = [result2, result3];
+            } else {
+              result2 = null;
+              pos = pos2;
+            }
+          } else {
+            result2 = null;
+            pos = pos2;
+          }
+          if (result2 !== null) {
+            result1 = [];
+            while (result2 !== null) {
+              result1.push(result2);
+              pos2 = pos;
+              if (input.charCodeAt(pos) === 46) {
+                result2 = ".";
+                pos++;
+              } else {
+                result2 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\".\"");
+                }
+              }
+              if (result2 !== null) {
+                result3 = parse_bareString();
+                if (result3 !== null) {
+                  result2 = [result2, result3];
+                } else {
+                  result2 = null;
+                  pos = pos2;
+                }
+              } else {
+                result2 = null;
+                pos = pos2;
+              }
+            }
+          } else {
+            result1 = null;
+          }
+          if (result1 !== null) {
+            result0 = [result0, result1];
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, parts) {
+            var args = ALLOY_EXPR + parts[0];
+            var len = parts[1] ? parts[1].length : 0;
+            for (var i = 0; i < len; i++) {
+              args += parts[1][i].join('');
+            }
+            return args;
+          })(pos0, result0);
+        }
+        if (result0 === null) {
+          pos = pos0;
         }
         return result0;
       }

--- a/Alloy/grammar/tss.pegjs
+++ b/Alloy/grammar/tss.pegjs
@@ -94,8 +94,19 @@ basevalue
   / "false" __ { return false;  }
   / "undefined" __  { return ALLOY_EXPR + "undefined"; }
   / "null" __  { return ALLOY_EXPR + "null"; }
+  / DollarArgs
 
 /* ===== Lexical Elements ===== */
+
+DollarArgs
+  = parts:("$.args" ('.' bareString)+) {
+    var args = ALLOY_EXPR + parts[0];
+    var len = parts[1] ? parts[1].length : 0;
+    for (var i = 0; i < len; i++) {
+      args += parts[1][i].join('');
+    }
+    return args;
+  }
 
 bitwise_operator "bitwise_operator"
   = ">>"


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1316

Not sure if it's a good idea to treat `'$.args.*'` as an expression. Maybe we should differentiate a `string` and a js `expression` when setting properties.