### PR TITLE
added optional failure callback on alloy/dialogs

### DIFF
--- a/Alloy/builtins/dialogs.js
+++ b/Alloy/builtins/dialogs.js
@@ -36,7 +36,7 @@ exports.buttonNames = ['No', 'Yes'];
  * @param {String} [args.yes="Yes"] Label of the affirmative button of the dialog box.
  * @param {String} [args.no="No"] Label of the negative button of the dialog box.
  * @param {Function} [args.callback] Callback function invoked after an affirmative response.
- * @param {Function} [args.failure] Callback function invoked after a failure response.
+ * @param {Function} [args.cancel] Callback function invoked after a negative response.
  * @param {...*} [args.evt] Callback context.
  */
 exports.confirm = function(args) {
@@ -57,8 +57,8 @@ exports.confirm = function(args) {
 			if (args.callback) {
 				args.callback(args.evt || {});
 			}
-		} else if (args.failure) {
-			args.failure(args.evt || {});
+		} else if (args.cancel) {
+			args.cancel(args.evt || {});
 		}
 		args = null;
 	});

--- a/Alloy/builtins/dialogs.js
+++ b/Alloy/builtins/dialogs.js
@@ -36,9 +36,10 @@ exports.buttonNames = ['No', 'Yes'];
  * @param {String} [args.yes="Yes"] Label of the affirmative button of the dialog box.
  * @param {String} [args.no="No"] Label of the negative button of the dialog box.
  * @param {Function} [args.callback] Callback function invoked after an affirmative response.
+ * @param {Function} [args.failure] Callback function invoked after a failure response.
  * @param {...*} [args.evt] Callback context.
  */
-exports.confirm = function (args) {
+exports.confirm = function(args) {
 	args = args || {};
 	if (args.buttonNames) {
 		args.no = args.no || args.buttonNames[0];
@@ -51,9 +52,13 @@ exports.confirm = function (args) {
 		buttonNames: [args.no || exports.buttonNames[0], args.yes || exports.buttonNames[1]],
 		cancel: 0
 	});
-	alertDialog.addEventListener('click', function (evt) {
+	alertDialog.addEventListener('click', function(evt) {
 		if (evt.index) {
-			if (args.callback) { args.callback(args.evt || {}); }
+			if (args.callback) {
+				args.callback(args.evt || {});
+			}
+		} else if (args.failure) {
+			args.failure(args.evt || {});
 		}
 		args = null;
 	});

--- a/Alloy/builtins/dialogs.js
+++ b/Alloy/builtins/dialogs.js
@@ -39,7 +39,7 @@ exports.buttonNames = ['No', 'Yes'];
  * @param {Function} [args.cancel] Callback function invoked after a negative response.
  * @param {...*} [args.evt] Callback context.
  */
-exports.confirm = function(args) {
+exports.confirm = function (args) {
 	args = args || {};
 	if (args.buttonNames) {
 		args.no = args.no || args.buttonNames[0];
@@ -52,7 +52,7 @@ exports.confirm = function(args) {
 		buttonNames: [args.no || exports.buttonNames[0], args.yes || exports.buttonNames[1]],
 		cancel: 0
 	});
-	alertDialog.addEventListener('click', function(evt) {
+	alertDialog.addEventListener('click', function (evt) {
 		if (evt.index) {
 			if (args.callback) {
 				args.callback(args.evt || {});


### PR DESCRIPTION
I've added an optional failure callback on alloy/dialogs. This way if 'No' is chosen I can run a function.