### PR TITLE
[ALOY-1626] Revert "Add plugins/ti.alloy to gitignore"

### DIFF
--- a/Alloy/template/gitignore.txt
+++ b/Alloy/template/gitignore.txt
@@ -10,4 +10,3 @@ tmp
 .project
 .settings
 Thumbs.db
-plugins/ti.alloy

--- a/templates/default/.gitignore
+++ b/templates/default/.gitignore
@@ -10,4 +10,3 @@ tmp
 .project
 .settings
 Thumbs.db
-plugins/ti.alloy

--- a/templates/two_tabbed/.gitignore
+++ b/templates/two_tabbed/.gitignore
@@ -10,4 +10,3 @@ tmp
 .project
 .settings
 Thumbs.db
-plugins/ti.alloy


### PR DESCRIPTION
**JIRA:**: https://jira.appcelerator.org/browse/ALOY-1626

Reverts appcelerator/alloy#883

@feons In which Alloy version can we ship this with?