### PR TITLE
[ALOY-1620] Replace custom copy file logic with fs-extra copySync call

### DIFF
--- a/Alloy/utils.js
+++ b/Alloy/utils.js
@@ -513,25 +513,7 @@ exports.resolveAppHome = function() {
 };
 
 exports.copyFileSync = function(srcFile, destFile) {
-	var BUF_LENGTH = 64 * 1024,
-		buff,
-		bytesRead,
-		fdr,
-		fdw,
-		pos;
-	buff = new Buffer(BUF_LENGTH);
-	fdr = fs.openSync(srcFile, 'r');
-	exports.ensureDir(path.dirname(destFile));
-	fdw = fs.openSync(destFile, 'w');
-	bytesRead = 1;
-	pos = 0;
-	while (bytesRead > 0) {
-		bytesRead = fs.readSync(fdr, buff, 0, BUF_LENGTH, pos);
-		fs.writeSync(fdw, buff, 0, bytesRead);
-		pos += bytesRead;
-	}
-	fs.closeSync(fdr);
-	return fs.closeSync(fdw);
+	fs.copySync(srcFile, destFile, { overwrite: true });
 };
 
 exports.ensureDir = function(p) {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1620

Rather than just change the Buffer usage, I just replaced the custom logic with an fs-extra call. I did some fairly unscientific testing and there's no noticeable performance difference