### PR TITLE
[ALOY-1631] Add "theme" CLI parameter

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -901,6 +901,9 @@ exports.parseConfig = function(file, alloyConfig, o) {
 				o = _.extend(o, j['os:' + alloyConfig.platform + ' ' + distType]);
 			}
 		}
+		if (alloyConfig.theme) {
+			o.theme = alloyConfig.theme;
+		}
 	}
 
 	return o;

--- a/hooks/alloy.js
+++ b/hooks/alloy.js
@@ -43,6 +43,7 @@ exports.init = function (logger, config, cli, appc) {
 
 		var cRequire = afs.resolvePath(__dirname, '..', 'Alloy', 'commands', 'compile', 'index.js'),
 			config = {
+				theme: cli.argv['theme'] ? cli.argv['theme'] : null,
 				platform: /(?:iphone|ipad)/.test(cli.argv.platform) ? 'ios' : cli.argv.platform,
 				version: '0',
 				simtype: 'none',


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/ALOY-1631

From [documentation](https://docs.appcelerator.com/platform/latest/#!/guide/Alloy_Themes)

> To use a theme, add it to your Alloy project's config.json file with "theme" as the key and the name of the theme folder as the value

For my application I need to apply different themes for customers, so it would be nice to have ability to define theme from command line.