### PR TITLE
[TIMOB-26403] Explicitly expose Alloy, _, and Backbone off the global object when it's available

### DIFF
--- a/Alloy/template/app.js
+++ b/Alloy/template/app.js
@@ -1,11 +1,18 @@
 /**
  * Alloy for Titanium by Appcelerator
  * This is generated code, DO NOT MODIFY - changes will be lost!
- * Copyright (c) 2012 by Appcelerator, Inc.
+ * Copyright (c) 2012-2018 by Appcelerator, Inc.
  */
-var Alloy = require('/alloy'),
+var Alloy = require('/alloy');
 	_ = Alloy._,
 	Backbone = Alloy.Backbone;
+// explicitly assign to global properties,
+// don't rely on implict assignment as it is going away
+if (global) {
+	global.Alloy = Alloy;
+	global._ = _;
+	global.Backbone = Backbone;
+}
 
 __MAPMARKER_ALLOY_JS__
 Alloy.createController('index');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alloy",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,20 @@
     "html5",
     "appc-client"
   ],
-  "version": "1.13.2",
+  "version": "1.13.3",
   "author": "Appcelerator, Inc. <info@appcelerator.com>",
   "maintainers": [
     {
       "name": "Tony Lukasavage",
       "email": "tlukasavage@appcelerator.com"
+    },
+    {
+      "name": "Feon Miao",
+      "email": "fmiao@axway.com"
+    },
+    {
+      "name": "Chris Williams",
+      "email": "cwilliams@axway.com"
     }
   ],
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "email": "tlukasavage@appcelerator.com"
     },
     {
-      "name": "Feon Miao",
+      "name": "Feon Sua",
       "email": "fmiao@axway.com"
     },
     {


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-26403

**Description:**
This modifies the `app.js` template so that we don't simply declare `Alloy`, `_`, and `Backbone` as top-level variables, we also explicitly assign them as properties off `global` when there is a `global`.

We intend to remove exposing top-level app.js variables as implicit globals in the future (SDK 9?).