### PR TITLE
fix(hooks): Only set theme if it's explicity set in command arguments

### DIFF
--- a/hooks/alloy.js
+++ b/hooks/alloy.js
@@ -43,7 +43,6 @@ exports.init = function (logger, config, cli, appc) {
 
 		var cRequire = afs.resolvePath(__dirname, '..', 'Alloy', 'commands', 'compile', 'index.js'),
 			config = {
-				theme: cli.argv['theme'] ? cli.argv['theme'] : null,
 				platform: /(?:iphone|ipad)/.test(cli.argv.platform) ? 'ios' : cli.argv.platform,
 				version: '0',
 				simtype: 'none',
@@ -55,6 +54,10 @@ exports.init = function (logger, config, cli, appc) {
 			// turn off all logging output for code analyzer build hook
 			config.noBanner = 'true';
 			config.logLevel = '-1';
+		}
+
+		if (cli.argv.theme) {
+			config.theme = cli.argv.theme;
 		}
 
 		config = Object.keys(config).map(function (c) {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/ALOY-1638

Only set config.theme if a theme was passed in