### PR TITLE
fix(optiondialog): do not set cancel and destructive properties if not in attributes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Program",
+			"program": "${workspaceFolder}/bin/alloy",
+			"args": [
+				"compile",
+				"--config",
+				"platform=ios"
+			],
+			"cwd": "/Users/eharris/Documents/Appcelerator_Studio_Workspace/plainAlloy",
+			"skipFiles": [
+				"node_modules/**/*.js",
+				"<node_internals>/**/*.js"
+			]
+		}
+	]
+}

--- a/Alloy/commands/compile/parsers/Alloy.Abstract._ItemContainer.js
+++ b/Alloy/commands/compile/parsers/Alloy.Abstract._ItemContainer.js
@@ -51,7 +51,17 @@ function parse(node, state, args) {
 			code += CU.generateNodeExtended(child, state, childState);
 			var prop = _.find(def.children, function(c) { return c.name === theNode; }).property;
 			extras.push([prop, childState.itemsArray]);
-			_.each(state.extraOptions, (v, k) => extras.push([k, v]));
+
+			// Only add the extraOptions if they are defined on the child nodes
+			_.each(U.XML.getElementsFromNodes(child.childNodes), (node) => {
+				_.each(state.extraOptions, (varName, name) => {
+					const attr = _.find(node.attributes, ['nodeName', name]);
+					if (attr !== undefined) {
+						extras.push([name, varName]);
+					}
+				});
+			});
+
 
 			// get rid of the node when we're done so we can pass the current state
 			// back to generateNode() and then process any additional views that

--- a/Alloy/commands/compile/parsers/Ti.UI.OptionDialog.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.OptionDialog.js
@@ -21,6 +21,9 @@ exports.parse = function(node, state) {
 
 	const newCode = _.map(state.extraOptions, (varName, name) => {
 		const attr = _.find(node.attributes, ['nodeName', name]);
+		if (attr === undefined) {
+			return;
+		}
 		return `var ${varName} = ${attr && attr.nodeValue}`;
 	}).join(';');
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Alloy Release Notes
+# Alloy Release Notes
 
 ### Unreleased items
 
@@ -14,7 +14,8 @@
 
 #### Fixes
 
-* [ALOY-1535](https://jira.appcelerator.org/browse/ALOY-1535) Only warn when using an AlertDialog with child views not restricted to Android
+* [ALOY-1535](https://jira.appcelerator.org/browse/ALOY-1535) Only warn when using an AlertDialog with child views not restricted to Android [#810](https://github.com/appcelerator/alloy/pull/810)
+* [ALOY-1653](https://jira.appcelerator.org/browse/ALOY-1653): Runtime error on Android when using optiondialog and not declaring destructive or cancel properties [#926](https://github.com/appcelerator/alloy/pull/926)
 
 ### Release 1.13.9
 


### PR DESCRIPTION
Setting these values to undefined on Android causes a runtime error when it attempts to build the event

Fixes [ALOY-1653](https://jira.appcelerator.org/browse/ALOY-1653)