### PR TITLE
fix(ios): fix fetch() on iOS due to unbound call to ResultSet.field

### DIFF
--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -224,7 +224,6 @@ function Sync(method, model, opts) {
 			var values = [];
 			var fieldNames = [];
 			var fieldCount = _.isFunction(rs.fieldCount) ? rs.fieldCount() : rs.fieldCount;
-			var getField = OS_ANDROID || OS_WINDOWS ? rs.field.bind(rs) : rs.field;
 			var i = 0;
 
 			for (; i < fieldCount; i++) {
@@ -235,7 +234,7 @@ function Sync(method, model, opts) {
 			while (rs.isValidRow()) {
 				var o = {};
 				for (i = 0; i < fieldCount; i++) {
-					o[fieldNames[i]] = getField(i);
+					o[fieldNames[i]] = rs.field(i);
 				}
 				values.push(o);
 				rs.next();


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-27053

**Description**
On Windows and Android we explicitly bound a reference to the ResultSet's field method to the instance
We did not on iOS, so changes to be more compliant on master resulted in an error
due to `this` being implicitly the global and not the ResultSet instance.
This is effectively the same issue as TIMOB-20577
Eliminated the redirection used to call the method altogether in favor of the more straight-forward
`rs.field(i)`.

Fixes TIMOB-27053