### PR TITLE
Remove os:windows from config.json

### DIFF
--- a/Alloy/template/config.json
+++ b/Alloy/template/config.json
@@ -5,6 +5,5 @@
 	"env:production": {},
 	"os:android": {},
 	"os:ios": {},
-	"os:windows": {},
 	"dependencies": {}
 }


### PR DESCRIPTION
Removing os:windows from config.json due to dropping Windows support since SDK 9.0