### PR TITLE
feat: add ability to run in background without UI

### DIFF
--- a/Alloy/template/app.js
+++ b/Alloy/template/app.js
@@ -13,4 +13,14 @@ global.Backbone = Backbone;
 
 __MAPMARKER_ALLOY_JS__
 
-Alloy.createController('index');
+// Open root window if a new UI session has started. Can happen more than once in app's lifetime.
+// Event can only be fired if "tiapp.xml" property "run-in-background" is set true.
+Ti.UI.addEventListener('sessionbegin', function () {
+	Alloy.createController('index');
+});
+
+// Open the root window immediately if an active UI session exists on startup.
+// Note: The Ti.UI.hasSession property was added as of Titanium 9.1.0.
+if ((typeof Ti.UI.hasSession === 'undefined') || Ti.UI.hasSession) {
+	Alloy.createController('index');
+}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/ALOY-1732

**Summary:**
This change is needed by [TIMOB-27896](https://jira.appcelerator.org/browse/TIMOB-27896) to support executing the "app.js" in the background before the app is capable of hosting UI. It also supports open the root window more than once when new UI sessions are created, which happens on Android when you back out of the app and relaunch for the same app process.
