### PR TITLE
refactor: fix invalid version comparisons

### DIFF
--- a/Alloy/builtins/animation.js
+++ b/Alloy/builtins/animation.js
@@ -21,7 +21,7 @@ exports.HORIZONTAL = 'horizontal';
 exports.VERTICAL = 'vertical';
 
 const create3DMatrix = Ti.UI.createMatrix3D ? Ti.UI.createMatrix3D : Ti.UI.create3DMatrix;
-const create2DMatrix = Ti.UI.createMatrix3D ? Ti.UI.createMatrix2D : Ti.UI.create2DMatrix;
+const create2DMatrix = Ti.UI.createMatrix2D ? Ti.UI.createMatrix2D : Ti.UI.create2DMatrix;
 
 /**
  * @method flip

--- a/Alloy/builtins/animation.js
+++ b/Alloy/builtins/animation.js
@@ -20,8 +20,8 @@ exports.HORIZONTAL = 'horizontal';
  */
 exports.VERTICAL = 'vertical';
 
-const create3DMatrix = Ti.version >= '8.0.0' ? Ti.UI.createMatrix3D : Ti.UI.create3DMatrix;
-const create2DMatrix = Ti.version >= '8.0.0' ? Ti.UI.createMatrix2D : Ti.UI.create2DMatrix;
+const create3DMatrix = Ti.UI.createMatrix3D ? Ti.UI.createMatrix3D : Ti.UI.create3DMatrix;
+const create2DMatrix = Ti.UI.createMatrix3D ? Ti.UI.createMatrix2D : Ti.UI.create2DMatrix;
 
 /**
  * @method flip

--- a/Alloy/template/lib/alloy.js
+++ b/Alloy/template/lib/alloy.js
@@ -33,7 +33,7 @@ exports.Backbone = Backbone;
 
 var DEFAULT_WIDGET = 'widget';
 var MW320_CHECK = OS_MOBILEWEB;
-var IDENTITY_TRANSFORM = OS_ANDROID ? (Ti.UI.createMatrix3D ? Ti.UI.createMatrix2D() : Ti.UI.create2DMatrix()) : undefined;
+var IDENTITY_TRANSFORM = OS_ANDROID ? (Ti.UI.createMatrix2D ? Ti.UI.createMatrix2D() : Ti.UI.create2DMatrix()) : undefined;
 var RESET = {
 	bottom: null,
 	left: null,

--- a/Alloy/template/lib/alloy.js
+++ b/Alloy/template/lib/alloy.js
@@ -32,9 +32,8 @@ exports._ = _;
 exports.Backbone = Backbone;
 
 var DEFAULT_WIDGET = 'widget';
-var TI_VERSION = Ti.version;
-var MW320_CHECK = OS_MOBILEWEB && TI_VERSION >= '3.2.0';
-var IDENTITY_TRANSFORM = OS_ANDROID ? (Ti.version >= '8.0.0' ? Ti.UI.createMatrix2D() : Ti.UI.create2DMatrix()) : undefined;
+var MW320_CHECK = OS_MOBILEWEB;
+var IDENTITY_TRANSFORM = OS_ANDROID ? (Ti.UI.createMatrix3D ? Ti.UI.createMatrix2D() : Ti.UI.create2DMatrix()) : undefined;
 var RESET = {
 	bottom: null,
 	left: null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### Unreleased items
 
+### Improvements
+
+* [ALOY-1256](https://jira.appcelerator.org/browse/ALOY-1256) - Allow using a Widget as a primary control in an XML View [#949](https://github.com/appcelerator/alloy/pull/949)
+* [ALOY-1253](https://jira.appcelerator.org/browse/ALOY-1253) - Support WPATH in widget XML view attribute values [#948](https://github.com/appcelerator/alloy/pull/948)
+
+### Bug Fixes
+
+* [ALOY-1720](https://jira.appcelerator.org/browse/ALOY-1720) - Version string comparison will break for SDK 10.0.0
+
 ### Release 1.14.6
 
 * [ALOY-1721](https://jira.appcelerator.org/browse/ALOY-1721) - Alloy global can no longer be accessed in styles [#955](https://github.com/appcelerator/alloy/issues/955)


### PR DESCRIPTION
JIRA: [ALOY-1720](https://jira.appcelerator.org/browse/ALOY-1720)

* Matrix calls - As we were using the version to basically do feature detection I went with checking if the functions existed rather than using an SDK version check
* M2_320 check - As we've dropped support for Mobilweb _and_ 3.2.0 is years old, I went with removing the version check and just having it be a `OS_MOBILEWEB` check