### PR TITLE
fix(runtime): use bootstrap mechanism to load globals rather than setting in the alloy.js file

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -480,6 +480,8 @@ module.exports = function(args, program) {
 
 	generateAppJs(paths, compileConfig, restrictionPath, compilerMakeFile);
 
+	U.copyFileSync(path.join(alloyRoot, 'template', 'alloy.bootstrap.js'), path.join(paths.resources, titaniumFolder, 'alloy.bootstrap.js'));
+
 	// ALOY-905: workaround TiSDK < 3.2.0 iOS device build bug where it can't reference app.js
 	// in platform-specific folders, so we just copy the platform-specific one to
 	// the Resources folder.

--- a/Alloy/template/alloy.bootstrap.js
+++ b/Alloy/template/alloy.bootstrap.js
@@ -1,0 +1,5 @@
+var Alloy = require('/alloy');
+
+global.Alloy = Alloy;
+global._ = Alloy._;
+global.Backbone = Alloy.Backbone;

--- a/Alloy/template/app.js
+++ b/Alloy/template/app.js
@@ -7,9 +7,13 @@ var Alloy = require('/alloy'),
 	_ = Alloy._,
 	Backbone = Alloy.Backbone;
 
-global.Alloy = Alloy;
-global._ = _;
-global.Backbone = Backbone;
+// The globals should be configured by the bootstrap script, however if anyone is using an SDK
+// older than 7.5.0 that won't get ran. So set them here if they don't exist
+if (!global.Alloy) {
+	global.Alloy = Alloy;
+	global._ = _;
+	global.Backbone = Backbone;
+}
 
 __MAPMARKER_ALLOY_JS__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ### Unreleased items
 
+### Release 1.15.0
+
 ### New Features
 
 * [ALOY-1732](https://jira.appcelerator.org/browse/ALOY-1732) - Add ability to run in the background without UI [#959](https://jira.appcelerator.org/browse/ALOY-1732)
+* [ALOY-1733](https://jira.appcelerator.org/browse/ALOY-1733) - Add template for Alloy + webpack usage [#963](https://github.com/appcelerator/alloy/pull/963)
 
 ### Improvements
 
@@ -13,7 +16,8 @@
 
 ### Bug Fixes
 
-* [ALOY-1720](https://jira.appcelerator.org/browse/ALOY-1720) - Version string comparison will break for SDK 10.0.0[#960](https://github.com/appcelerator/alloy/pull/960)
+* [ALOY-1720](https://jira.appcelerator.org/browse/ALOY-1720) - Version string comparison will break for SDK 10.0.0 [#960](https://github.com/appcelerator/alloy/pull/960)
+* [ALOY-1734](https://jira.appcelerator.org/browse/ALOY-1734) - Declare Alloy globals before execution of app.js/alloy.js [#964](https://github.com/appcelerator/alloy/pull/964)
 
 ### Release 1.14.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alloy",
-  "version": "1.15.0-1",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "html5",
     "appc-client"
   ],
-  "version": "1.15.0-1",
+  "version": "1.15.0",
   "author": "Appcelerator, Inc. <info@appcelerator.com>",
   "maintainers": [
     {
@@ -75,8 +75,5 @@
     "eslint": "^4.14.0",
     "jake": "^8.0.12",
     "mkdirp": "^0.5.1"
-  },
-  "publishConfig": {
-    "tag": "next"
   }
 }


### PR DESCRIPTION
Fixes [ALOY-1734](https://jira.appcelerator.org/browse/ALOY-1734)

* `alloy.bootstrap.js` will be loaded at startup before the `app.js`, this ensures that the globals are correctly configured _before_ the `app.js` is even executed.
* Check if the globals exist in the `app.js` and set them if they don't, this should keep us compatible with SDKs pre-7.5.0 (i.e. those without the bootstrap feature, if you're using an SDK that old ... please, please, please update ASAP)

Test steps - see jira