### PR TITLE
fix: Use items in ListSection 

### DIFF
--- a/Alloy/commands/compile/parsers/Ti.UI.ListSection.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.ListSection.js
@@ -161,7 +161,7 @@ function parse(node, state, args) {
 			items: itemCode,
 			post: 'opts.animation ? ' +
 				sps + '.setItems(' + itemsVar + ', opts.animation) : ' +
-				sps + '.setItems(' + itemsVar + ');'
+				sps + '.items = ' + itemsVar + ';'
 		});
 	}
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/AC-6585

Use `items = ` instead of deprecated `setItems()`. Will get rid of the warnings.