### PR TITLE
fix: handle widget case explicitly and revert back to previous default behaviour

### DIFF
--- a/Alloy/commands/compile/parsers/Alloy.Require.js
+++ b/Alloy/commands/compile/parsers/Alloy.Require.js
@@ -134,7 +134,7 @@ function parse(node, state, args) {
 	};
 	if (args.parent.symbol && !state.templateObject && !state.androidMenu) {
 		code += ';\n' + args.symbol + '.setParent(' + args.parent.symbol + ');\n';
-	} else if (type === 'widget') {
+	} else if (type === 'widget' && (node.parentNode && node.parentNode.nodeName === 'Alloy')) {
 		code += '.getViewEx({recurse:true});\n';
 		parent = { symbol: args.symbol };
 	} else {

--- a/Alloy/commands/compile/parsers/Alloy.Require.js
+++ b/Alloy/commands/compile/parsers/Alloy.Require.js
@@ -129,19 +129,16 @@ function parse(node, state, args) {
 		args.createArgs,
 		state
 	) + ')';
-	let parent = { symbol: args.symbol };
-	if (args.parent.symbol && !state.templateObject && !state.androidMenu && !state.insideContainer) {
+	let parent = {
+		symbol: args.symbol + '.getViewEx({recurse:true})'
+	};
+	if (args.parent.symbol && !state.templateObject && !state.androidMenu) {
 		code += ';\n' + args.symbol + '.setParent(' + args.parent.symbol + ');\n';
-		parent = {
-			symbol: args.symbol + '.getViewEx({recurse:true})'
-		};
-	} else if ( state.insideContainer ) {
-		code += ';\n';
-		parent = {
-			symbol: args.symbol + '.getViewEx({recurse:true})'
-		};
-	} else {
+	} else if (type === 'widget') {
 		code += '.getViewEx({recurse:true});\n';
+		parent = { symbol: args.symbol };
+	} else {
+		code += ';\n';
 	}
 
 	return {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased items
 
+### Release 1.15.2
+
 ### Bug Fixes
 
 * [ALOY-1737](https://jira.appcelerator.org/browse/ALOY-1737) - Set items directly in ListView [#966](https://github.com/appcelerator/alloy/pull/966)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased items
 
+### Bug Fixes
+
+* [ALOY-1737](https://jira.appcelerator.org/browse/ALOY-1737) - Set items directly in ListView [#966](https://github.com/appcelerator/alloy/pull/966)
+* [ALOY-1738](https://jira.appcelerator.org/browse/ALOY-1738) - Fix handling of Require tags [#967](https://github.com/appcelerator/alloy/pull/967)
+
 ### Release 1.15.1
 
 ## Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alloy",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "html5",
     "appc-client"
   ],
-  "version": "1.15.1",
+  "version": "1.15.2",
   "author": "Appcelerator, Inc. <info@appcelerator.com>",
   "maintainers": [
     {


### PR DESCRIPTION
Fixes [ALOY-1738](https://jira.appcelerator.org/browse/ALOY-1738)

cc @brentonhouse I've verified that [brentonhouse/alloy-widget-test](https://github.com/brentonhouse/alloy-widget-test) still work with this change, do you have any other usage of top levels widgets?