### PR TITLE
build: replace mkdirp with fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "diff": "^3.4.0",
     "eslint": "^7.5.0",
     "jake": "^8.0.12",
-    "mkdirp": "^0.5.1",
     "semantic-release": "^17.1.2"
   },
   "release": {

--- a/test/lib/JunitReporter.js
+++ b/test/lib/JunitReporter.js
@@ -216,9 +216,9 @@
             }
 
             function nodeWrite(path, filename, text) {
-                var fs = require("fs");
+                var fs = require("fs-extra");
                 var nodejs_path = require("path");
-                require("mkdirp").sync(path); // make sure the path exists
+                fs.mkdirpSync(path);
                 var filepath = nodejs_path.join(path, filename);
                 var xmlfile = fs.openSync(filepath, "w");
                 fs.writeSync(xmlfile, text, 0);


### PR DESCRIPTION
Replaces the test usage of mkdirp with usage of `mkdirpSync` from fs-extra. This is used in the junit file writing, so if Jenkins picks that file up ok, and danger reports the stats ok we're groovy