### PR TITLE
refactor: remove chmodr

### DIFF
--- a/Alloy/commands/compile/BuildLog.js
+++ b/Alloy/commands/compile/BuildLog.js
@@ -1,5 +1,4 @@
 var fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	path = require('path'),
 	CONST = require('../../common/constants'),
 	logger = require('../../logger');
@@ -25,7 +24,6 @@ function BuildLog(_projectPath) {
 	// make sure the alloy build folder exists
 	if (!fs.existsSync(dir)) {
 		fs.mkdirpSync(dir);
-		chmodr.sync(dir, 0755);
 	}
 
 	// load it up

--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -4,7 +4,6 @@ var U = require('../../utils'),
 	os = require('os'),
 	fs = require('fs-extra'),
 	walkSync = require('walk-sync'),
-	chmodr = require('chmodr'),
 	jsonlint = require('jsonlint'),
 	logger = require('../../logger'),
 	astController = require('./ast/controller'),
@@ -635,7 +634,6 @@ exports.copyWidgetResources = function(resources, resourceDir, widgetId, opts) {
 				var dest = path.join(destDir, path.basename(file));
 				if (!path.existsSync(destDir)) {
 					fs.mkdirpSync(destDir);
-					chmodr.sync(destDir, 0755);
 				}
 
 				logger.trace('Copying ' + file.yellow + ' --> ' +
@@ -701,8 +699,9 @@ exports.mergeI18N = function mergeI18N(src, dest, opts) {
 			if (!fs.existsSync(srcFile)) return;
 
 			if (fs.statSync(srcFile).isDirectory()) {
-				fs.existsSync(destFile) || fs.mkdirpSync(destFile);
-				chmodr.sync(destFile, 0755);
+				if (!fs.existsSync(destFile)) {
+					fs.mkdirpSync(destFile);
+				}
 				return walk(srcFile, destFile);
 			}
 
@@ -868,7 +867,6 @@ function generateConfig(obj) {
 		buildLog.data.cfgHash = hash;
 		// write out the config runtime module
 		fs.mkdirpSync(resourcesBase);
-		chmodr.sync(resourcesBase, 0755);
 
 		//logger.debug('Writing "Resources/' + (platform ? platform + '/' : '') + 'alloy/CFG.js"...');
 		var output = 'module.exports=' + JSON.stringify(o) + ';';
@@ -878,7 +876,6 @@ function generateConfig(obj) {
 		var baseFolder = path.join(obj.dir.resources, 'alloy');
 		if (!fs.existsSync(baseFolder)) {
 			fs.mkdirpSync(baseFolder);
-			chmodr.sync(baseFolder, 0755);
 		}
 		fs.writeFileSync(path.join(baseFolder, 'CFG.js'), output);
 	}

--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -2,7 +2,6 @@ var ejs = require('ejs'),
 	path = require('path'),
 	fs = require('fs-extra'),
 	walkSync = require('walk-sync'),
-	chmodr = require('chmodr'),
 	vm = require('vm'),
 	babel = require('@babel/core'),
 	async = require('async'),
@@ -255,7 +254,6 @@ module.exports = function(args, program) {
 	_.each(['COMPONENT', 'WIDGET', 'RUNTIME_STYLE'], function(type) {
 		var p = path.join(paths.resources, titaniumFolder, 'alloy', CONST.DIR[type]);
 		fs.mkdirpSync(p);
-		chmodr.sync(p, 0755);
 	});
 
 	// Copy in all developer assets, libs, and additional resources
@@ -363,7 +361,6 @@ module.exports = function(args, program) {
 		fs.removeSync(destPlatformDir);
 	}
 	fs.mkdirpSync(destPlatformDir);
-	chmodr.sync(destPlatformDir, 0755);
 	fs.writeFileSync(path.join(destPlatformDir, 'alloy_generated'), generateMessage('platform'));
 	sourcePlatformDirs.forEach(function (dir) {
 		var dirs = [ dir ];
@@ -388,7 +385,6 @@ module.exports = function(args, program) {
 		fs.removeSync(destI18NDir);
 	}
 	fs.mkdirpSync(destI18NDir);
-	chmodr.sync(destI18NDir, 0755);
 	fs.writeFileSync(path.join(destI18NDir, 'alloy_generated'), generateMessage('i18n'));
 	sourceI18NPaths.forEach(function (dir) {
 		if (fs.existsSync(dir)) {
@@ -910,14 +906,10 @@ function parseAlloyComponent(view, dir, manifest, noView, fileRestriction) {
 			path.join(compileConfig.dir.resources, titaniumFolder, 'alloy', CONST.DIR.WIDGET,
 				manifest.id, widgetDir)
 		);
-		chmodr.sync(path.join(compileConfig.dir.resources, titaniumFolder, 'alloy', CONST.DIR.WIDGET,
-			manifest.id, widgetDir), 0755);
 		fs.mkdirpSync(
 			path.join(compileConfig.dir.resources, titaniumFolder, 'alloy', CONST.DIR.WIDGET,
 				manifest.id, widgetStyleDir)
 		);
-		chmodr.sync(path.join(compileConfig.dir.resources, titaniumFolder, 'alloy', CONST.DIR.WIDGET,
-			manifest.id, widgetStyleDir), 0755);
 
 		// [ALOY-967] merge "i18n" dir in widget folder
 		CU.mergeI18N(path.join(dir, 'i18n'), path.join(compileConfig.dir.project, 'i18n'), { override: false });
@@ -1021,7 +1013,6 @@ function parseAlloyComponent(view, dir, manifest, noView, fileRestriction) {
 		styleCode += _.template(fs.readFileSync(path.join(alloyRoot, 'template', 'wpath.js'), 'utf8'))({ WIDGETID: manifest.id });
 	}
 	fs.mkdirpSync(path.dirname(runtimeStylePath));
-	chmodr.sync(path.dirname(runtimeStylePath), 0755);
 	fs.writeFileSync(runtimeStylePath, styleCode);
 }
 
@@ -1101,7 +1092,6 @@ function processModels(dirs) {
 					titaniumFolder, 'alloy', 'widgets', manifest.id, 'models');
 			}
 			fs.mkdirpSync(modelRuntimeDir);
-			chmodr.sync(modelRuntimeDir, 0755);
 			fs.writeFileSync(path.join(modelRuntimeDir, casedBasename + '.js'), code);
 			models.push(basename);
 		});

--- a/Alloy/commands/compile/sourceMapper.js
+++ b/Alloy/commands/compile/sourceMapper.js
@@ -4,7 +4,6 @@
 */
 var SM = require('source-map'),
 	fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	path = require('path'),
 	U = require('../../utils'),
 	CONST = require('../../common/constants'),
@@ -143,7 +142,6 @@ exports.generateCodeAndSourceMap = function(generator, compileConfig) {
 
 	// write the generated controller code
 	fs.mkdirpSync(path.dirname(outfile));
-	chmodr.sync(path.dirname(outfile), 0755);
 	fs.writeFileSync(outfile, outputResult.code.toString());
 	logger.info('  created:    "' + relativeOutfile + '"');
 
@@ -153,7 +151,6 @@ exports.generateCodeAndSourceMap = function(generator, compileConfig) {
 		outfile = path.join(mapDir, relativeOutfile) + '.' + CONST.FILE_EXT.MAP;
 		relativeOutfile = path.relative(compileConfig.dir.project, outfile);
 		fs.mkdirpSync(path.dirname(outfile));
-		chmodr.sync(path.dirname(outfile), 0755);
 		fs.writeFileSync(outfile, JSON.stringify(sourceMap));
 	}
 };
@@ -229,7 +226,6 @@ exports.generateSourceMap = function(generator, compileConfig) {
 	var mapDir = path.join(compileConfig.dir.project, CONST.DIR.MAP);
 	var outfile = path.join(mapDir, relativeOutfile) + '.' + CONST.FILE_EXT.MAP;
 	fs.mkdirpSync(path.dirname(outfile));
-	chmodr.sync(path.dirname(outfile), 0755);
 	fs.writeFileSync(outfile, JSON.stringify(mapper.toJSON()));
 	logger.debug('  map:        "' + outfile + '"');
 };

--- a/Alloy/commands/extract-i18n/i18nHandler.js
+++ b/Alloy/commands/extract-i18n/i18nHandler.js
@@ -4,7 +4,6 @@ var U = require('../../utils'),
 	_ = require('lodash'),
 	XMLSerializer = require('xmldom').XMLSerializer,
 	fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	os = require('os');
 
 var FILE_TEMPLATE = '<?xml version="1.0" encoding="UTF-8"?>' + os.EOL + '<resources>' +
@@ -25,7 +24,6 @@ module.exports = function(projectRoot, language) {
 	// create 18n folder if it doesn't exist
 	if (!fs.existsSync(i18nDir)) {
 		fs.mkdirpSync(i18nDir);
-		chmodr.sync(i18nDir, 0755);
 	}
 
 	// create i18n file if it doesn't exist

--- a/Alloy/commands/generate/targets/widget.js
+++ b/Alloy/commands/generate/targets/widget.js
@@ -1,6 +1,5 @@
 var path = require('path'),
 	fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	jsonlint = require('jsonlint'),
 	U = require('../../../utils'),
 	_ = require('lodash'),
@@ -27,14 +26,12 @@ module.exports = function(name, args, program) {
 			CONST.FILE_EXT[type]);
 
 		fs.mkdirpSync(typeFolder);
-		chmodr.sync(typeFolder, 0755);
 		fs.writeFileSync(
 			path.join(typeFolder, CONST.NAME_WIDGET_DEFAULT + '.' + CONST.FILE_EXT[type]),
 			fs.readFileSync(typeTemplate, 'utf8')
 		);
 	});
 	fs.mkdirpSync(path.join(paths.widget, CONST.DIR.ASSETS));
-	chmodr.sync(path.join(paths.widget, CONST.DIR.ASSETS), 0755);
 
 	// create widget.json manifest file
 	fs.writeFileSync(

--- a/Alloy/commands/new/index.js
+++ b/Alloy/commands/new/index.js
@@ -8,7 +8,6 @@
 */
 var path = require('path'),
 	fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	_ = require('lodash'),
 	U = require('../../utils'),
 	CONST = require('../../common/constants'),
@@ -35,7 +34,6 @@ module.exports = async function(args, program) {
 		}
 	}
 	fs.mkdirpSync(paths.app);
-	chmodr.sync(paths.app, 0755);
 
 	// copy platform-specific folders from Resources to app/assets
 	_.each(CONST.PLATFORM_FOLDERS, function(platform) {
@@ -43,7 +41,6 @@ module.exports = async function(args, program) {
 		if (fs.existsSync(rPath)) {
 			var aPath = path.join(paths.app, CONST.DIR.ASSETS, platform);
 			fs.mkdirpSync(aPath);
-			chmodr.sync(aPath, 0755);
 			fs.copySync(rPath, aPath, {preserveTimestamps:true});
 		}
 	});
@@ -51,7 +48,6 @@ module.exports = async function(args, program) {
 	// add alloy-specific folders
 	_.each(appDirs, function(dir) {
 		fs.mkdirpSync(path.join(paths.app, dir));
-		chmodr.sync(path.join(paths.app, dir), 0755);
 	});
 
 	// move existing i18n and platform directories into app directory
@@ -167,7 +163,6 @@ module.exports = async function(args, program) {
 
 		var p = path.join(paths.app, 'assets', dir);
 		fs.mkdirpSync(p);
-		chmodr.sync(p, 0755);
 		fs.copySync(rDir, p);
 	});
 
@@ -205,7 +200,6 @@ module.exports = async function(args, program) {
 		if (fs.existsSync(path.join(sampleAppsDir, program.testapp, 'specs'))) {
 			// copy in the test harness
 			fs.mkdirpSync(path.join(paths.app, 'lib'));
-			chmodr.sync(path.join(paths.app, 'lib'), 0755);
 			fs.copySync(path.join(path.resolve(sampleAppsDir, '..'), 'lib'), path.join(paths.app, 'lib'), {preserveTimestamps:true});
 		}
 	}

--- a/Alloy/utils.js
+++ b/Alloy/utils.js
@@ -3,7 +3,6 @@
 var path = require('path'),
 	fs = require('fs-extra'),
 	walkSync = require('walk-sync'),
-	chmodr = require('chmodr'),
 	colors = require('colors'),
 	crypto = require('crypto'),
 	util = require('util'),
@@ -165,7 +164,6 @@ exports.getAndValidateProjectPaths = function(argPath, opts) {
 	var appjs = path.join(paths.resources, 'app.js');
 	if (!fs.existsSync(appjs)) {
 		fs.mkdirpSync(paths.resources);
-		chmodr.sync(paths.resources, 0755);
 		fs.writeFileSync(appjs, '');
 	}
 
@@ -205,7 +203,6 @@ exports.updateFiles = function(srcDir, dstDir, opts) {
 
 	if (!fs.existsSync(dstDir)) {
 		fs.mkdirpSync(dstDir);
-		chmodr.sync(dstDir, 0755);
 	}
 
 	// don't process XML/controller files inside .svn folders (ALOY-839)
@@ -269,7 +266,6 @@ exports.updateFiles = function(srcDir, dstDir, opts) {
 			if (srcStat.isDirectory()) {
 				logger.trace('Creating directory ' + path.relative(opts.rootDir, dst).yellow);
 				fs.mkdirpSync(dst);
-				chmodr.sync(dst, 0755);
 			} else {
 				logger.trace('Copying ' + path.join('SRC_DIR', path.relative(srcDir, src)).yellow +
 					' --> ' + path.relative(opts.rootDir, dst).yellow);
@@ -519,7 +515,6 @@ exports.copyFileSync = function(srcFile, destFile) {
 exports.ensureDir = function(p) {
 	if (!fs.existsSync(p)) {
 		fs.mkdirpSync(p);
-		chmodr.sync(p, 0755);
 	}
 };
 

--- a/jakelib/app.jake
+++ b/jakelib/app.jake
@@ -1,5 +1,4 @@
 var fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	path = require('path'),
 	os = require('os'),
 	U = require('../Alloy/utils'),
@@ -109,7 +108,6 @@ namespace('app', function() {
 		log('Reseting the Harness app from template...');
 		fs.removeSync(harnessAppPath);
 		fs.mkdirpSync(harnessAppPath);
-		chmodr.sync(harnessAppPath, 0777);
 		fs.copySync(harnessTemplatePath, harnessAppPath);
 	});
 
@@ -118,7 +116,6 @@ namespace('app', function() {
 		log('Initializing Alloy project...');
 		if (!path.existsSync(resourcesPath)) {
 			fs.mkdirpSync(resourcesPath);
-			chmodr.sync(resourcesPath, 0777);
 		}
 		require('child_process').exec('alloy new -f "' + harnessAppPath + '"', function(error, stdout, stderr) {
 			if (error) {
@@ -130,7 +127,6 @@ namespace('app', function() {
 				log('Staging sample app "'+appDir+'" for launch...');
 				fs.copySync(path.join(process.cwd(), 'test', 'apps', appDir), targetAppPath, {preserveTimestamps:true});
 				fs.mkdirpSync(path.join(targetAppPath,'lib'));
-				chmodr.sync(path.join(targetAppPath,'lib'), 0777);
 				fs.copySync(
 					path.join('test','lib'),
 					path.join(targetAppPath,'lib'),
@@ -159,7 +155,6 @@ namespace('app', function() {
 		log('Initializing Alloy project...');
 		if (!path.existsSync(resourcesPath)) {
 			fs.mkdirpSync(resourcesPath);
-			chmodr.sync(resourcesPath, 0777);
 		}
 		require('child_process').exec('alloy new -f "' + harnessAppPath + '"', function(error, stdout, stderr) {
 			if (error) {
@@ -171,7 +166,6 @@ namespace('app', function() {
 				log('Staging sample app "'+appDir+'" for launch...');
 				fs.copySync(path.join(process.cwd(), 'test', 'apps', appDir), targetAppPath, {preserveTimestamps:true});
 				fs.mkdirpSync(path.join(targetAppPath,'lib'));
-				chmodr.sync(path.join(targetAppPath,'lib'), 0777);
 				fs.copySync(
 					path.join('test','lib'),
 					path.join(targetAppPath,'lib'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -2293,11 +2293,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "chmodr": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
-      "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk="
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/types": "^7.4.4",
     "@babel/template": "^7.4.4",
     "async": "^3.2.0",
-    "chmodr": "^1.0.2",
     "colors": "^1.1.2",
     "commander": "^2.12.2",
     "ejs": "3.1.5",

--- a/test/lib/testUtils.js
+++ b/test/lib/testUtils.js
@@ -1,6 +1,5 @@
 var exec = require('child_process').exec,
 	fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	os = require('os'),
 	path = require('path'),
 	JsDiff = require('diff'),
@@ -28,7 +27,6 @@ function resetTestApp(callback) {
 	var paths = exports.paths;
 	fs.removeSync(paths.harness);
 	fs.mkdirpSync(paths.harness);
-	chmodr.sync(paths.harness, 0777);
 	fs.copySync(paths.harnessTemplate, paths.harness);
 	exec('alloy new "' + paths.harness + '"', function(error, stdout, stderr) {
 		if (error) {

--- a/test/specs/compilefile.js
+++ b/test/specs/compilefile.js
@@ -1,5 +1,4 @@
 var fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	path = require('path'),
 	DOMParser = require('xmldom').DOMParser,
 	TU = require('../lib/testUtils'),
@@ -24,7 +23,6 @@ describe('alloy selective compile', function() {
 		// Create a copy of Harness to work with
 		fs.removeSync(Harness);
 		fs.mkdirpSync(Harness);
-		chmodr.sync(Harness, 0777);
 		fs.copySync(HarnessTemplate, Harness, {
 			forceDelete: true
 		});

--- a/test/specs/new.js
+++ b/test/specs/new.js
@@ -1,5 +1,4 @@
 var fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	path = require('path'),
 	DOMParser = require('xmldom').DOMParser,
 	TU = require('../lib/testUtils'),
@@ -73,7 +72,6 @@ _.each(RUNS, function(run) {
 			// Create a copy of Harness to work with
 			fs.removeSync(Harness);
 			fs.mkdirpSync(Harness);
-			chmodr.sync(Harness, 0777);
 			fs.copySync(HarnessTemplate, Harness, {
 				forceDelete: true
 			});

--- a/tools/create_generated_code.js
+++ b/tools/create_generated_code.js
@@ -1,5 +1,4 @@
 var fs = require('fs-extra'),
-	chmodr = require('chmodr'),
 	path = require('path'),
 	platforms = require('../platforms/index'),
 	_ = require('lodash'),
@@ -58,7 +57,6 @@ function doCompile(platform) {
 		var genDir = path.join(paths.apps, testApp, '_generated', platform);
 		fs.removeSync(genDir);
 		fs.mkdirpSync(genDir);
-		chmodr.sync(genDir, 0777);
 
 		var locations = [
 			path.join('alloy', 'controllers'),
@@ -70,7 +68,6 @@ function doCompile(platform) {
 			var dst = path.join(genDir, l);
 			if (fs.existsSync(src) && fs.readdirSync(src).length !== 0) {
 				fs.mkdirpSync(dst);
-				chmodr.sync(dst, 0777);
 				fs.copySync(src, dst);
 
 				// we don't need to evaluate BaseController.js every time


### PR DESCRIPTION
The file permissions that get set are ultimately only preserved when alloy creates the files in
Resources, when the SDK copies the files over to the application binary these ultimately become the
system defaults. Furthermore, files were incorrectly being given 755 permissions on first creation
and then changed to 644 on an incremental build.

We will now just use the node defaults for these files rather than setting them, files will be
given 644 and folders will be given 777

Tested against kitchensink and pko and I'm seeing no negative consequences of doing this