### PR TITLE
fix(compile): allow TabGroup as child of a NavigationWindow

### DIFF
--- a/Alloy/commands/compile/parsers/Ti.UI.NavigationWindow.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.NavigationWindow.js
@@ -32,7 +32,7 @@ function parse(node, state, args) {
 
 	var child = children[0],
 		childArgs = CU.getParserArgs(child),
-		theNode = CU.validateNodeName(child, 'Ti.UI.Window'),
+		theNode = CU.validateNodeName(child, 'Ti.UI.Window') || CU.validateNodeName(child, 'Ti.UI.TabGroup'),
 		windowSymbol;
 
 	// generate the code for the Window first

--- a/Alloy/commands/compile/parsers/Ti.UI.NavigationWindow.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.NavigationWindow.js
@@ -6,6 +6,7 @@ var _ = require('lodash'),
 
 const MIN_VERSION_FOR_IOS = '3.1.3';
 const MIN_VERSION = '8.0.0';
+const MIN_ANDROID_TABGROUP_CHILD = '8.3.0';
 
 exports.parse = function(node, state) {
 	return require('./base').parse(node, state, parse);
@@ -13,6 +14,7 @@ exports.parse = function(node, state) {
 
 function parse(node, state, args) {
 	const tiappSdkVersion = tiapp.getSdkVersion();
+	const platform =  CU.getCompilerConfig().alloyConfig.platform;
 	if (tiapp.version.lt(tiappSdkVersion, MIN_VERSION_FOR_IOS)) {
 		U.die(`Ti.UI.iOS.NavigationWindow (line ${node.lineNumber}) requires Titanium ${MIN_VERSION_FOR_IOS}+`);
 	}
@@ -22,20 +24,24 @@ function parse(node, state, args) {
 	}
 
 	var children = U.XML.getElementsFromNodes(node.childNodes),
-		err = ['NavigationWindow must have only one child element, which must be a Window'],
+		err = ['NavigationWindow must have only one child element, which must be a Window or TabGroup'],
 		code = '';
 
-	// NavigationWindow must have 1 window as a child
+	// NavigationWindow must have 1 window or tabgroup as a child
 	if (children.length !== 1) {
 		U.die(err);
 	}
 
 	var child = children[0],
 		childArgs = CU.getParserArgs(child),
-		theNode = CU.validateNodeName(child, 'Ti.UI.Window') || CU.validateNodeName(child, 'Ti.UI.TabGroup'),
+		theNode = CU.validateNodeName(child, [ 'Ti.UI.Window', 'Ti.UI.TabGroup' ]),
 		windowSymbol;
 
-	// generate the code for the Window first
+	if (platform === 'android' && theNode === 'Ti.UI.TabGroup' && tiapp.version.lt(tiappSdkVersion, MIN_ANDROID_TABGROUP_CHILD)) {
+		U.die(`TabGroup can only be a child of a NavigationWindow on Android from SDK ${MIN_ANDROID_TABGROUP_CHILD} onwards. Current SDK is ${tiappSdkVersion}`);
+	}
+
+	// generate the code for the child first
 	if (theNode) {
 		code += CU.generateNodeExtended(child, state, {
 			parent: {},


### PR DESCRIPTION
After https://github.com/appcelerator/titanium_mobile/pull/11166 it is allowed to have a TabGroup inside a NavigationWindow but Alloy currently doesn't allow it. 

This change will fix the compiling error

```
<Alloy>
	<NavigationWindow>
		<TabGroup title="Tabgroup">
			<Tab title="tab">
				<Window/>
			</Tab>
			<Tab title="tab">
				<Window/>
			</Tab>
		</TabGroup>
	</NavigationWindow>
</Alloy>
```

