### PR TITLE
Fix for Ti >=9; Backbone no longer global

### DIFF
--- a/Alloy/lib/alloy/sync/properties.js
+++ b/Alloy/lib/alloy/sync/properties.js
@@ -1,6 +1,7 @@
 var Alloy = require('/alloy'),
 	_ = require('/alloy/underscore')._,
-	TAP = Ti.App.Properties;
+	TAP = Ti.App.Properties,
+  Backbone = Alloy.Backbone;
 
 function S4() {
 	return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);


### PR DESCRIPTION
As of Ti 9, globals are not supported. Without this fix, the properties adapter no longer works as Backbone would be undefined.