### PR TITLE
ci: add actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,14 @@ jobs:
         run: npm run lint
   Test:
     needs: Lint
-    name: ${{ matrix.os }} Node.js ${{ matrix.nodeVersion }} Ti SDK ${{ matrix.sdk }} Tests
+    name: ${{ matrix.os }} Node.js ${{ matrix.nodeVersion }} Ti SDK ${{ matrix.tiSDK }} Tests
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         nodeVersion: [ '12.x' ]
         os: [ macos-latest ]
-        tiSDK: [ GA, '-b master' ] # -b master is to reduce the complexity of handling a GA install vs a branch install
+        tiSDK: [ latest, '-b master' ] # -b master is to reduce the complexity of handling a GA install vs a branch install
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+on:
+  - pull_request
+  - push
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+  Test:
+    needs: Lint
+    name: ${{ matrix.os }} Node.js ${{ matrix.nodeVersion }} Ti SDK ${{ matrix.sdk }} Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        nodeVersion: [ '12.x' ]
+        os: [ macos-latest ]
+        tiSDK: [ GA, '-b master' ] # -b master is to reduce the complexity of handling a GA install vs a branch install
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.nodeVersion }}
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm i titanium -g
+          ti sdk install ${{ matrix.tiSDK }} -d
+      - name: Run tests
+        run: npm test
+      

--- a/test/lib/testUtils.js
+++ b/test/lib/testUtils.js
@@ -18,6 +18,10 @@ exports.paths = {
 	harness: path.join(alloyRoot,'test','projects','Harness')
 };
 
+function createEnv () {
+	return Object.assign(process.env, { PATH: `${process.env.PATH}${path.delimiter}${path.join(process.cwd(), 'bin')}`})
+}
+
 // Recreate the test app harness
 //
 // Params:
@@ -28,11 +32,11 @@ function resetTestApp(callback) {
 	fs.removeSync(paths.harness);
 	fs.mkdirpSync(paths.harness);
 	fs.copySync(paths.harnessTemplate, paths.harness);
-	exec('alloy new "' + paths.harness + '"', function(error, stdout, stderr) {
+	exec('alloy new "' + paths.harness + '"', {env: createEnv() }, function(error, stdout, stderr) {
 		if (error) {
 			console.error('Failed to create new alloy project at ' + paths.harness);
 			console.error(stderr);
-			process.exit();
+			process.exit(1);
 		}
 		callback();
 	});
@@ -76,7 +80,7 @@ exports.asyncExecTest = function(cmd, opts) {
 		self.done = false;
 
 		var asyncFunc = function() {
-			exec(cmd, function() {
+			exec(cmd, { env: createEnv() }, function() {
 				self.done = true;
 				self.output = getExecObject(arguments);
 			});

--- a/test/specs/compile.js
+++ b/test/specs/compile.js
@@ -43,6 +43,8 @@ exec('ti sdk list --output json', function(error, stdout, stderr){
 });
 */
 
+delete platforms.mobileweb;
+
 var alloyRoot = path.join(__dirname,'..','..'),
 	paths = {
 		apps: path.join(alloyRoot,'test','apps'),


### PR DESCRIPTION
Setups GitHub actions and also does the following in tests:

* Adds `./bin/alloy` to process.env in tests to ensure we're always using the local alloy
* Removes the testing of mobileweb in (mostly failed) attempt to reduce the test time (cut around 5 minutes off)