### PR TITLE
feat(all): set default backbone version

### DIFF
--- a/Alloy/template/config.json
+++ b/Alloy/template/config.json
@@ -5,5 +5,6 @@
 	"env:production": {},
 	"os:android": {},
 	"os:ios": {},
-	"dependencies": {}
+	"dependencies": {},
+	"backbone": "1.4.0"
 }

--- a/templates/default/app/config.json
+++ b/templates/default/app/config.json
@@ -6,5 +6,6 @@
 	"os:android": {},
 	"os:ios": {},
 	"os:windows": {},
-	"dependencies": {}
+	"dependencies": {},
+	"backbone": "1.4.0"
 }

--- a/templates/two_tabbed/app/config.json
+++ b/templates/two_tabbed/app/config.json
@@ -6,5 +6,6 @@
 	"os:android": {},
 	"os:ios": {},
 	"os:windows": {},
-	"dependencies": {}
+	"dependencies": {},
+	"backbone": "1.4.0"
 }

--- a/templates/webpack-default/app/config.json
+++ b/templates/webpack-default/app/config.json
@@ -6,5 +6,6 @@
 	"os:android": {},
 	"os:ios": {},
 	"os:windows": {},
-	"dependencies": {}
+	"dependencies": {},
+	"backbone": "1.4.0"
 }


### PR DESCRIPTION
This way new apps will use the newer Backbone version and not the very old default 0.9.2! Old/existing apps will still use 0.9.2 when no other version is defined and still work. Raising the constant in https://github.com/appcelerator/alloy/blob/master/Alloy/common/constants.js#L49 could break existing apps.