### PR TITLE
fix(compile/hook): error if unable to find the alloy cli

### DIFF
--- a/hooks/alloy.js
+++ b/hooks/alloy.js
@@ -123,6 +123,12 @@ exports.init = function (logger, config, cli, appc) {
 				};
 			}), function () {
 
+				if (!paths.alloy) {
+					logger.error('The alloy CLI is not installed');
+					logger.error('Please install it with [sudo] npm i alloy -g');
+					process.exit(1);
+				}
+
 				// compose alloy command execution
 				var cmd = [paths.node, paths.alloy, 'compile', appDir, '--config', config];
 				if (cli.argv['no-colors'] || cli.argv['color'] === false) { cmd.push('--no-colors'); }
@@ -193,9 +199,5 @@ exports.init = function (logger, config, cli, appc) {
 			target = build.target;
 
 		run(build.deviceFamily, deployType, target, finished);
-	});
-
-	cli.addHook('codeprocessor.pre.run', function (build, finished) {
-		run('none', 'development', undefined, finished, SILENT);
 	});
 };


### PR DESCRIPTION
This updates the Alloy compile hook so that if the alloy CLI cannot be found rather than outputting the below confusing error that doesn't inform the user what the problem is

```text
[INFO]  Executing Alloy compile: /Users/awam/.nvm/versions/node/v16.13.0/bin/node  compile /Users/awam/Documents/Appcelerator_Studio_Workspace/plainalloy/app --config platform=android,version=0,simtype=none,devicefamily=none,deploytype=development,target=emulator
[DEBUG] node:internal/modules/cjs/loader:936
[DEBUG]   throw err;
[DEBUG]   ^
[ERROR] : Cannot find module '/Users/awam/Documents/Appcelerator_Studio_Workspace/plainalloy/undefined'
[DEBUG]     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
[DEBUG]     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
[DEBUG]     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
[DEBUG]     at node:internal/main/run_main_module:17:47 {
[DEBUG]   code: 'MODULE_NOT_FOUND',
[DEBUG]   requireStack: []
[DEBUG] } 
[ERROR] Alloy compiler failed
```

It now outputs the below with information on what the problem is and how to fix it:

```text
[INFO]  Found Alloy app in /Users/awam/Documents/Appcelerator_Studio_Workspace/plainalloy/app
[ERROR] The alloy CLI is not installed
[ERROR] Please install it with [sudo] npm i alloy -g
```

However, this does require one build to have taken place so that the hook can be updated.