### PR TITLE
feat: add missing parser files

### DIFF
--- a/Alloy/commands/compile/parsers/Ti.UI.ActivityIndicator.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.ActivityIndicator.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Column.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Column.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.MaskedImage.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.MaskedImage.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Notification.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Notification.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.ProgressBar.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.ProgressBar.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.RefreshControl.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.RefreshControl.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Row.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Row.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.SearchBar.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.SearchBar.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Shortcut.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Shortcut.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.ShortcutItem.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.ShortcutItem.js
@@ -1,0 +1,9 @@
+var CU = require('../compilerUtils');
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	return require('./default').parse(node, state);
+}


### PR DESCRIPTION
Adding default parser files for some UI elements.

The autocompletion parsers use these files to generate the `completions-v3.json`. Currently you can't type `<Acti` to get the autocompletion for `<ActivityIndicator>`. This PR will add those files and when you clear your `.titanium/completions/titanium/13.1.1.GA/` files and let Pulsar rebuild those it will find the missing elements.