### PR TITLE
fix: deprecation warning for existsSync

### DIFF
--- a/Alloy/commands/new/index.js
+++ b/Alloy/commands/new/index.js
@@ -260,7 +260,7 @@ function getPaths(project, templateName, testapp) {
 		// alloy paths
 		alloy: alloy,
 		template: path.join(alloy, 'template'),
-		readme: fs.existsSync(readMeFile) ? readMeFile : path.join(template, 'README'),
+		readme: readMeFile != undefined && fs.existsSync(readMeFile) ? readMeFile : path.join(template, 'README'),
 		appTemplate: (!testapp) ? customAppDir || path.join(projectTemplates, templateName, 'app') : path.join(sampleAppsDir, testapp),
 		projectTemplate: (!testapp) ? customTemplateDir || path.join(projectTemplates, templateName) : path.join(sampleAppsDir, testapp),
 


### PR DESCRIPTION
fixes: https://github.com/tidev/alloy/issues/1440

Output afterwards is just:
```
[INFO]  Creating app project
[INFO]  Template directory: /home/miga/.titanium/mobilesdk/linux/13.1.1.GA/templates/app/default
[INFO]  Writing tiapp.xml
[INFO]  Project created successfully in 12ms

[INFO] Deployed ti.alloy plugin to /home/miga/tmp/asdf/plugins/ti.alloy/plugin.py
[INFO] Deployed ti.alloy hook to /home/miga/tmp/asdf/plugins/ti.alloy/hooks/alloy.js
[INFO] Deployed ti.alloy cleanhook to /home/miga/tmp/asdf/plugins/ti.alloy/hooks/deepclean.js
[INFO] Installed "ti.alloy" plugin to /home/miga/tmp/asdf/tiapp.xml
[INFO] Generated new project at: /home/miga/tmp/asdf/app
```
and project has a `README.md`