### PR TITLE
feat: allow comma separated class selectors

### DIFF
--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -195,9 +195,13 @@ exports.sortStyles = function(style, opts) {
 	var sortedStyles = [];
 	opts = opts || {};
 
+	function splitSelectors(key) {
+		return key.split(/,(?![^[]]*\])/).map(function(k) { return k.trim(); }).filter(Boolean);
+	}
+
 	if (_.isObject(style) && !_.isEmpty(style)) {
 		for (var key in style) {
-			var keys = key.split(',').map(function(k) { return k.trim(); });
+			var keys = splitSelectors(key);
 			_.each(keys, function(singleKey) {
 				var obj = {};
 				var priority = styleOrderCounter++ * VALUES.ORDER;

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -197,61 +197,62 @@ exports.sortStyles = function(style, opts) {
 
 	if (_.isObject(style) && !_.isEmpty(style)) {
 		for (var key in style) {
-			var obj = {};
-			var priority = styleOrderCounter++ * VALUES.ORDER;
-			var match = key.match(STYLE_REGEX);
-			if (match === null) {
-				U.die('Invalid style specifier "' + key + '"');
-			}
-			var newKey = match[2];
+			var keys = key.split(',').map(function(k) { return k.trim(); });
+			_.each(keys, function(singleKey) {
+				var obj = {};
+				var priority = styleOrderCounter++ * VALUES.ORDER;
+				var match = singleKey.match(STYLE_REGEX);
+				if (match === null) {
+					U.die('Invalid style specifier "' + singleKey + '"');
+				}
+				var newKey = match[2];
 
-			// skip any invalid style entries
-			if (newKey === 'undefined' && !match[1]) { continue; }
+				if (newKey === 'undefined' && !match[1]) { return; }
 
-			// get the style key type
-			switch (match[1]) {
-				case '#':
-					obj.isId = true;
-					priority += VALUES.ID;
-					break;
-				case '.':
-					obj.isClass = true;
-					priority += VALUES.CLASS;
-					break;
-				default:
-					if (match[2]) {
-						obj.isApi = true;
-						priority += VALUES.API;
-					}
-					break;
-			}
+				switch (match[1]) {
+					case '#':
+						obj.isId = true;
+						priority += VALUES.ID;
+						break;
+					case '.':
+						obj.isClass = true;
+						priority += VALUES.CLASS;
+						break;
+					default:
+						if (match[2]) {
+							obj.isApi = true;
+							priority += VALUES.API;
+						}
+						break;
+				}
 
-			if (match[3]) {
-				obj.queries = {};
-				_.each(match[3].replace(/\s*,\s*/g, ',').split(/\s+/), function(query) {
-					var parts = query.split('=');
-					var q = U.trim(parts[0]);
-					var v = U.trim(parts[1]);
-					if (q === 'platform') {
-						priority += VALUES.PLATFORM + VALUES.SUM;
-						v = v.split(',');
-					} else if (q === 'formFactor') {
-						priority += VALUES.FORMFACTOR + VALUES.SUM;
-					} else if (q === 'if') {
-						priority += VALUES.TSSIF + VALUES.SUM;
-					} else {
-						priority += VALUES.SUM;
-					}
-					obj.queries[q] = v;
+				if (match[3]) {
+					obj.queries = {};
+					_.each(match[3].replace(/\s*,\s*/g, ',').split(/\s+/), function(query) {
+						var parts = query.split('=');
+						var q = U.trim(parts[0]);
+						var v = U.trim(parts[1]);
+						if (q === 'platform') {
+							priority += VALUES.PLATFORM + VALUES.SUM;
+							v = v.split(',');
+						} else if (q === 'formFactor') {
+							priority += VALUES.FORMFACTOR + VALUES.SUM;
+						} else if (q === 'if') {
+							priority += VALUES.TSSIF + VALUES.SUM;
+						} else {
+							priority += VALUES.SUM;
+						}
+						obj.queries[q] = v;
+					});
+				}
+
+				_.extend(obj, {
+					priority: priority + (opts.platform ? VALUES.PLATFORM : 0) + (opts.theme ? VALUES.THEME : 0),
+					key: newKey,
+					style: style[key]
 				});
-			}
-
-			_.extend(obj, {
-				priority: priority + (opts.platform ? VALUES.PLATFORM : 0) + (opts.theme ? VALUES.THEME : 0),
-				key: newKey,
-				style: style[key]
+				sortedStyles.push(obj);
 			});
-			sortedStyles.push(obj);
 		}
 	}
 

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -196,7 +196,28 @@ exports.sortStyles = function(style, opts) {
 	opts = opts || {};
 
 	function splitSelectors(key) {
-		return key.split(/,(?![^[]]*\])/).map(function(k) { return k.trim(); }).filter(Boolean);
+		const result = [];
+		let current = '';
+		let depth = 0;
+
+		for (let i = 0, len = key.length; i < len; i++) {
+			const char = key[i];
+
+			if (char === '[') {
+				depth++;
+			} else if (char === ']') {
+				depth--;
+			} else if (char === ',' && depth === 0) {
+				if (current) result.push(current.trim());
+				current = '';
+				continue;
+			}
+
+			current += char;
+		}
+
+		if (current) result.push(current.trim());
+		return result;
 	}
 
 	if (_.isObject(style) && !_.isEmpty(style)) {


### PR DESCRIPTION
This PR will allow the user to have selectors like `'.btn, .btn2'` (like in HTML)
Need to do some more testing and see if there are no other cases where a comma is allowed in the selector. 
```xml
<Alloy>
  <Window layout="vertical">
    <Button class="btn">Button 1</Button>
    <Button class="btn2">Button 2</Button>
  </Window>
</Alloy>
```
```
'.btn, .btn2': {
  backgroundColor: 'red'
}

'.btn2': {
  color: 'green'
}
```

<img width="344" height="100" alt="Screenshot_20260412-143206" src="https://github.com/user-attachments/assets/e339de8f-82be-483b-b43e-4ca553f41368" />

The later style will override the parts of the first so 
```
'.btn, .btn2': {
  backgroundColor: 'red',
  color: 'blue'
}

'.btn2': {
  color: 'green'
}
```

will only make the first button text color blue.


All tests pass: 2778 specs, 0 failures
two bigger Alloy apps still look fine, so nothing broke in existing styles.