### PR TITLE
code updates and fixes

### DIFF
--- a/Alloy/alloy.js
+++ b/Alloy/alloy.js
@@ -14,8 +14,7 @@ var program = require('commander'),
 	fs = require('fs'),
 	CONST = require('./common/constants');
 
-// patch to remove the warning in node >=0.8
-path.existsSync = fs.existsSync || path.existsSync;
+
 
 // avoid io issues on Windows in nodejs 0.10.X: https://github.com/joyent/node/issues/3584
 if (process.env.ALLOY_TESTS && /^win/i.test(os.platform())) {
@@ -144,7 +143,7 @@ function getCommands() {
 	try {
 		var commandsPath = path.join(__dirname, 'commands');
 		return _.filter(fs.readdirSync(commandsPath), function(file) {
-			return path.existsSync(path.join(commandsPath, file, 'index.js'));
+			return fs.existsSync(path.join(commandsPath, file, 'index.js'));
 		});
 	} catch (e) {
 		U.die('Error getting command list', e);

--- a/Alloy/builtins/social.js
+++ b/Alloy/builtins/social.js
@@ -157,7 +157,7 @@ OAuth == null && (OAuth = {}), OAuth.setProperties = function(into, from) {
 		if (s == null) return '';
 		if (s instanceof Array) {
 			var e = '';
-			for (var i = 0; i < s.length; ++s) e != '' && (e += '&'), e += OAuth.percentEncode(s[i]);
+			for (var i = 0; i < s.length; ++i) e != '' && (e += '&'), e += OAuth.percentEncode(s[i]);
 			return e;
 		}
 		return s = encodeURIComponent(s), s = s.replace(/\!/g, '%21'), s = s.replace(/\*/g, '%2A'), s = s.replace(/\'/g, '%27'), s = s.replace(/\(/g, '%28'), s = s.replace(/\)/g, '%29'), s;

--- a/Alloy/commands/compile/Orphanage.js
+++ b/Alloy/commands/compile/Orphanage.js
@@ -277,8 +277,7 @@ function isException(file, exceptions) {
 		// handle folder wildcards
 		if (ex.charAt(ex.length - 1) === '*') {
 			for (var j = 0; j < exs.length; j++) {
-				var newEx = exs[i].substr(0, exs[i].length - 2);
-
+				var newEx = exs[j].substr(0, exs[j].length - 2);
 				// see if the file starts with the wildcard
 				if (file.length >= newEx.length && file.substr(0, newEx.length) === newEx) {
 					return true;

--- a/Alloy/commands/compile/ast/builtins-plugin.js
+++ b/Alloy/commands/compile/ast/builtins-plugin.js
@@ -21,7 +21,7 @@ function appendExtension(file, extension) {
 }
 
 function loadBuiltin(source, name, dest) {
-	if (!path.existsSync(source)) {
+	if (!fs.existsSync(source)) {
 		return;
 	}
 

--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -610,7 +610,7 @@ exports.copyWidgetResources = function(resources, resourceDir, widgetId, opts) {
 	}
 
 	_.each(resources, function(dir) {
-		if (!path.existsSync(dir)) { return; }
+		if (!fs.existsSync(dir)) { return; }
 		logger.trace('WIDGET_SRC=' + path.relative(compilerConfig.dir.project, dir));
 		var files = walkSync(dir);
 		_.each(files, function(file) {
@@ -633,7 +633,7 @@ exports.copyWidgetResources = function(resources, resourceDir, widgetId, opts) {
 
 				var destDir = path.join(resourceDir, dirname, widgetId);
 				var dest = path.join(destDir, path.basename(file));
-				if (!path.existsSync(destDir)) {
+				if (!fs.existsSync(destDir)) {
 					fs.mkdirpSync(destDir);
 				}
 
@@ -676,11 +676,11 @@ exports.copyWidgetResources = function(resources, resourceDir, widgetId, opts) {
 				fs.copySync(widgetAssetSourceDir, widgetAssetTargetDir, {preserveTimestamps: true});
 			}
 			// platform-specific assets from the widget must override those of the theme
-			if (platform && path.existsSync(path.join(resources[0], platform))) {
+			if (platform && fs.existsSync(path.join(resources[0], platform))) {
 				fs.copySync(path.join(resources[0], platform), widgetAssetTargetDir, {preserveTimestamps: true});
 			}
 			// however platform-specific theme assets must override the platform assets from the widget
-			if (platform && path.existsSync(path.join(widgetAssetSourceDir, platform))) {
+			if (platform && fs.existsSync(path.join(widgetAssetSourceDir, platform))) {
 				logger.trace('Processing platform-specific theme assets for the ' + widgetId + ' widget');
 				widgetAssetSourceDir = path.join(widgetAssetSourceDir, platform);
 				fs.copySync(widgetAssetSourceDir, widgetAssetTargetDir, {preserveTimestamps: true});
@@ -691,7 +691,7 @@ exports.copyWidgetResources = function(resources, resourceDir, widgetId, opts) {
 				var files = walkSync(widgetAssetTargetDir);
 				_.each(files, function(file) {
 					var source = path.join(widgetAssetTargetDir, file);
-					if (path.existsSync(source) && fs.statSync(source).isDirectory()) {
+					if (fs.existsSync(source) && fs.statSync(source).isDirectory()) {
 						fs.removeSync(source);
 					}
 				});
@@ -855,14 +855,14 @@ function generateConfig(obj) {
 	var resourcesCfg = path.join(resourcesBase, 'CFG.js');
 
 	// parse config.json, if it exists
-	if (path.existsSync(appCfg)) {
+	if (fs.existsSync(appCfg)) {
 		o = exports.parseConfig(appCfg, alloyConfig, o);
 
 		if (o.theme) {
 			var themeCfg = path.join(obj.dir.home, 'themes', o.theme, 'config.' + CONST.FILE_EXT.CONFIG);
 
 			// parse theme config.json, if it exists
-			if (path.existsSync(themeCfg)) {
+			if (fs.existsSync(themeCfg)) {
 				o = exports.parseConfig(themeCfg, alloyConfig, o);
 			}
 		}
@@ -944,7 +944,7 @@ exports.loadController = function(file) {
 
 	// Read the controller file
 	try {
-		if (!path.existsSync(file)) {
+		if (!fs.existsSync(file)) {
 			return code;
 		}
 		contents = fs.readFileSync(file, 'utf8');

--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -21,7 +21,14 @@ var alloyRoot = path.join(__dirname, '..', '..'),
 	alloyUniqueIdPrefix = '__alloyId',
 	alloyUniqueIdCounter = 0,
 	JSON_NULL = JSON.parse('null'),
-	compilerConfig;
+	compilerConfig,
+	parserFileNames;
+
+// cache parsers directory listing (avoid readdirSync per element)
+(function initParserCache() {
+	var parsersDir = path.join(alloyRoot, 'commands', 'compile', 'parsers');
+	parserFileNames = fs.readdirSync(parsersDir);
+})();
 
 ///////////////////////////////
 ////////// constants //////////
@@ -334,9 +341,8 @@ exports.generateNode = function(node, state, defaultId, isTopLevel, isModelOrCol
 	}
 
 	// Determine which parser to use for this node
-	var parsersDir = path.join(alloyRoot, 'commands', 'compile', 'parsers');
 	var parserRequire = 'default';
-	if (_.includes(fs.readdirSync(parsersDir), args.fullname + '.js')) {
+	if (_.includes(parserFileNames, args.fullname + '.js')) {
 		parserRequire = args.fullname + '.js';
 	}
 

--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -42,7 +42,15 @@ var times = {
 };
 
 var fileRestrictionUpdatedFiles = [],
-	restrictionSkipOptimize = false;
+	restrictionSkipOptimize = false,
+	templateCache = {};
+
+function getCompiledTemplate(name) {
+	if (!templateCache[name]) {
+		templateCache[name] = _.template(fs.readFileSync(path.join(alloyRoot, 'template', name), 'utf8'));
+	}
+	return templateCache[name];
+}
 
 //////////////////////////////////////
 ////////// command function //////////
@@ -605,7 +613,7 @@ function parseAlloyComponent(view, dir, manifest, noView, fileRestriction) {
 			Widget: !manifest ? '' : 'var ' + CONST.WIDGET_OBJECT +
 				" = new (require('/alloy/widget'))('" + manifest.id + "');this.__widgetId='" +
 				manifest.id + "';",
-			WPATH: !manifest ? '' : _.template(fs.readFileSync(path.join(alloyRoot, 'template', 'wpath.js'), 'utf8'))({ WIDGETID: manifest.id }),
+			WPATH: !manifest ? '' : getCompiledTemplate('wpath.js')({ WIDGETID: manifest.id }),
 			__MAPMARKER_CONTROLLER_CODE__: '',
 			ES6Mod: ''
 		},
@@ -893,7 +901,7 @@ function parseAlloyComponent(view, dir, manifest, noView, fileRestriction) {
 	// create generated controller module code for this view/controller or widget
 	var controllerCode = template.__MAPMARKER_CONTROLLER_CODE__;
 	delete template.__MAPMARKER_CONTROLLER_CODE__;
-	var code = _.template(fs.readFileSync(path.join(compileConfig.dir.template, 'component.js'), 'utf8'))(template);
+	var code = getCompiledTemplate('component.js')(template);
 
 	// prep the controller paths based on whether it's an app
 	// controller or widget controller
@@ -1010,7 +1018,7 @@ function parseAlloyComponent(view, dir, manifest, noView, fileRestriction) {
 	// write out the pre-processed styles to runtime module files
 	var styleCode = 'module.exports = [' + processedStyles.join(',') + '];';
 	if (manifest) {
-		styleCode += _.template(fs.readFileSync(path.join(alloyRoot, 'template', 'wpath.js'), 'utf8'))({ WIDGETID: manifest.id });
+		styleCode += getCompiledTemplate('wpath.js')({ WIDGETID: manifest.id });
 	}
 	fs.mkdirpSync(path.dirname(runtimeStylePath));
 	fs.writeFileSync(runtimeStylePath, styleCode);

--- a/Alloy/commands/compile/parsers/Alloy.Abstract._BackboneClass.js
+++ b/Alloy/commands/compile/parsers/Alloy.Abstract._BackboneClass.js
@@ -1,4 +1,5 @@
 var path = require('path'),
+	fs = require('fs'),
 	walkSync = require('walk-sync'),
 	CU = require('../compilerUtils'),
 	U = require('../../../utils'),
@@ -30,7 +31,7 @@ function parse(node, state, args) {
 		// Make sure there's models to be used as the "src" of the Backbone class
 		var modelsPath = path.join(CU.getCompilerConfig().dir.home, CONST.DIR.MODEL);
 		var validModels;
-		if (!path.existsSync(modelsPath) || !(validModels = walkSync(modelsPath)).length) {
+		if (!fs.existsSync(modelsPath) || !(validModels = walkSync(modelsPath)).length) {
 			U.dieWithNode(node, [
 				'You must have a valid model in your app/' + CONST.DIR.MODEL + ' folder to create a <' + nodeName + '>',
 				'Once you have a valid model, assign it like this for a singleton:',
@@ -50,7 +51,7 @@ function parse(node, state, args) {
 			]);
 		} else {
 			var modelPath = path.join(modelsPath, src + '.' + CONST.FILE_EXT.MODEL);
-			if (!path.existsSync(modelPath)) {
+			if (!fs.existsSync(modelPath)) {
 				U.dieWithNode(node, [
 					'"src" attribute\'s model "' + src + '" does not exist in app/' + CONST.DIR.MODEL,
 					'Valid models: ' + validModelsPrint

--- a/Alloy/commands/compile/sourceMapper.js
+++ b/Alloy/commands/compile/sourceMapper.js
@@ -214,22 +214,6 @@ exports.generateSourceMap = function(generator, compileConfig) {
 		}
 	});
 
-	// parse composite code into an AST
-	// TODO: Remove? This is a sanity check, I suppose, but is it necessary?
-	// Our classic build should blow up on bad JS files
-	var ast;
-	try {
-		ast = babylon.parse(genMap.code, {
-			sourceFilename: genMap.file,
-			sourceType: 'unambiguous',
-			allowReturnOutsideFunction: true,
-		});
-	} catch (e) {
-		const filename = path.relative(compileConfig.dir.project, generator.target.template);
-
-		U.dieWithCodeFrame(`Error parsing code in ${filename}. ${e.message}`, e.loc, genMap.code);
-	}
-
 	// TODO: We do not run the babel plugins (optimizer/builtins) here. Is that ok?
 	// TODO: embed sourcesContent into source map? Shouldn't need to since this is supposed to be a straight copy
 

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -139,7 +139,7 @@ exports.loadGlobalStyles = function(appPath, opts) {
 	// get rid of entries that don't exist
 	var len = loadArray.length;
 	for (var i = len - 1; i >= 0; i--) {
-		if (!path.existsSync(loadArray[i].path)) {
+		if (!fs.existsSync(loadArray[i].path)) {
 			loadArray.splice(i, 1);
 		}
 	}
@@ -162,7 +162,7 @@ exports.loadGlobalStyles = function(appPath, opts) {
 
 		// create the new global style object
 		_.each(loadArray, function(g) {
-			if (path.existsSync(g.path)) {
+			if (fs.existsSync(g.path)) {
 				logger.info('[' + g.msg + '] global style processing...');
 				exports.globalStyle = exports.loadAndSortStyle(g.path, _.extend(
 					{ existingStyle: exports.globalStyle },
@@ -260,7 +260,7 @@ exports.sortStyles = function(style, opts) {
 };
 
 exports.loadStyle = function(tssFile) {
-	if (path.existsSync(tssFile)) {
+	if (fs.existsSync(tssFile)) {
 		// read the style file
 		var contents;
 		var originalContents;

--- a/Alloy/commands/generate/targets/jmk.js
+++ b/Alloy/commands/generate/targets/jmk.js
@@ -10,7 +10,7 @@ module.exports = function(name, args, program) {
 	var templatePath = path.join(alloyRoot, 'template', filename);
 
 	// only overwrite if using force option
-	if (path.existsSync(filepath) && !program.force) {
+	if (fs.existsSync(filepath) && !program.force) {
 		U.die('"alloy.jmk" file already exists. Use "-f,--force" to overwrite.');
 	}
 

--- a/Alloy/commands/generate/targets/style.js
+++ b/Alloy/commands/generate/targets/style.js
@@ -46,7 +46,7 @@ module.exports = function(name, args, program) {
 
 				// make sure the target folder exists
 				var fullDir = path.dirname(style_path);
-				if (!path.existsSync(fullDir)) {
+				if (!fs.existsSync(fullDir)) {
 					fs.mkdirpSync(fullDir);
 				}
 				targets.push({

--- a/Alloy/commands/generate/targets/widget.js
+++ b/Alloy/commands/generate/targets/widget.js
@@ -15,7 +15,7 @@ module.exports = function(name, args, program) {
 	var paths = getPaths(thePaths.app, widgetId);
 
 	// don't overwrite an existing widget unless force is specified
-	if (path.existsSync(paths.widget) && !program.force) {
+	if (fs.existsSync(paths.widget) && !program.force) {
 		U.die('Widget already exists: ' + paths.widget);
 	}
 
@@ -45,7 +45,7 @@ module.exports = function(name, args, program) {
 	);
 
 	// Add this widget as a dependency to our project
-	var configReadPath = path.existsSync(paths.config) ? paths.config : paths.configTemplate;
+	var configReadPath = fs.existsSync(paths.config) ? paths.config : paths.configTemplate;
 	var content = fs.readFileSync(configReadPath, 'utf8');
 	try {
 		var json = jsonlint.parse(content);

--- a/Alloy/lib/alloy/sync/sql.js
+++ b/Alloy/lib/alloy/sync/sql.js
@@ -236,15 +236,18 @@ function Sync(method, model, opts) {
 			}
 
 			// iterate through all queried rows
-			while (rs.isValidRow()) {
-				var o = {};
-				for (i = 0; i < fieldCount; i++) {
-					o[fieldNames[i]] = rs.field(i);
+			try {
+				while (rs.isValidRow()) {
+					var o = {};
+					for (i = 0; i < fieldCount; i++) {
+						o[fieldNames[i]] = rs.field(i);
+					}
+					values.push(o);
+					rs.next();
 				}
-				values.push(o);
-				rs.next();
+			} finally {
+				rs.close();
 			}
-			rs.close();
 
 			// shape response based on whether it's a model or collection
 			var len = values.length;

--- a/Alloy/template/lib/alloy.js
+++ b/Alloy/template/lib/alloy.js
@@ -202,6 +202,12 @@ exports.C = function(name, modelDesc, model) {
 	return Collection;
 };
 
+function resolveNS(ns) {
+	var parts = ns.split('.'), obj = global, i = 0;
+	for (; i < parts.length; i++) { obj = obj[parts[i]]; }
+	return obj;
+}
+
 exports.UI = {};
 exports.UI.create = function(controller, apiName, opts) {
 	opts = opts || {};
@@ -225,7 +231,7 @@ exports.UI.create = function(controller, apiName, opts) {
 	var style = exports.createStyle(controller, opts);
 
 	// create the titanium proxy object
-	return eval(ns)['create' + baseName](style);
+	return resolveNS(ns)['create' + baseName](style);
 };
 
 exports.createStyle = function(controller, opts, defaults) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "html5",
     "appc-client"
   ],
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "TiDev, Inc. <npm@tidev.io>",
   "bugs": {
     "url": "https://github.com/tidev/alloy/issues"


### PR DESCRIPTION
**Fixes:**

* remove all **path.existsSync** (see comment in current Alloy/alloy.js: patch to remove the warning in node >=0.8)
* **Alloy/builtins/social.js**: ++s instead of ++i in percentEncode — causes guaranteed app hang when called with Array arg
* **Alloy/commands/compile/Orphanage.js**: Inner loop uses outer variable i instead of j — wildcard file exclusion matching is completely broken
* **Alloy/lib/alloy/sync/sql.js**: DB cursor leak on exception — rs.close() never called if loop body throws

**Performance improvments:**
* **Cached readdirSync in per-element hot loop**
**compilerUtils.js** — The parsers directory was listed on every XML element (hundreds of times per compile). Now cached at module init in parserFileNames.
Before: fs.readdirSync(parsersDir) inside generateNode() (every XML element)  
After: parserFileNames populated once at load via IIFE, used by _.includes()

* **Replaced eval() with property chain walk**
**template/lib/alloy.js:228** — eval(ns) prevented V8 optimization for every Alloy.UI.create() call. Replaced with resolveNS() that walks the global object property chain via a simple for loop.
Before: `return eval(ns)['create' + baseName](style);  `
After: `return resolveNS(ns)['create' + baseName](style);`

* **Cached compiled template functions**
**index.js** — Three locations were reading template files from disk and calling _.template() (compile step) on every component iteration. Now cached in templateCache via getCompiledTemplate().
Files cached:
   - **wpath.js** — was read+compiled at lines 608 and 1013 per widget component
   - **component.js** — was read+compiled at line 896 per view/controller
Before: _.template(fs.readFileSync(...)) repeated per iteration  
After: getCompiledTemplate(name) reads+compiles once, returns cached function

* **Removed the redundant babylon.parse sanity check in generateSourceMap** (lines 217-231): Generated code is parsed into an AST purely as validation, then babel.transformFromAstSync parses it again internally. The first parse is wasted CPU. It parsed the code into an AST purely to catch syntax errors, then discarded it without ever using it. The TODO comment even asked "Remove? This is a sanity check...", confirming it was dead work.

All tests are still working: 2778 specs, 0 failures
and I've tested two apps with and without liveview and they look and behave the same.

On a very large Alloy project `alloy compile --config platform=android` went from 4.9s to 4.6s