### PR TITLE
fix: attach ES6 named exports to controller exports

### DIFF
--- a/Alloy/commands/compile/ast/controller.js
+++ b/Alloy/commands/compile/ast/controller.js
@@ -13,11 +13,20 @@ let GENCODE_OPTIONS = {
 exports.processController = function(code, file, isProduction = false) {
 	var baseController = '',
 		moduleCodes = '',
-		newCode = '',
-		exportSpecifiers = [];
+		newCode = '';
 
 	if (isProduction) {
 		GENCODE_OPTIONS.retainLines = false;
+	}
+
+	function buildExportAssignment(exportedName, localName) {
+		return types.expressionStatement(
+			types.assignmentExpression(
+				'=',
+				types.memberExpression(types.identifier('exports'), types.identifier(exportedName)),
+				types.identifier(localName)
+			)
+		);
 	}
 
 	try {
@@ -55,37 +64,53 @@ exports.processController = function(code, file, isProduction = false) {
 
 			ExportNamedDeclaration: function(path) {
 				var node = path.node;
-				var specifiers = node.specifiers;
-				if (specifiers && specifiers.length !== 0) {
-					specifiers.forEach(function (specifier) {
-						if (specifier.local && specifier.local.name) {
-							exportSpecifiers.push(specifier.local.name);
-						}
-					});
+
+				// Re-exports from another module (e.g. `export { foo } from './bar'`) are true
+				// module-level constructs — hoist them out of the controller body.
+				if (node.source) {
+					moduleCodes += generate(node, GENCODE_OPTIONS).code;
+					path.remove();
+					return;
 				}
+
+				// `export function show() {}`, `export const show = ...`, `export class X {}`
+				if (node.declaration) {
+					var decl = node.declaration;
+					var replacements = [decl];
+					if (decl.type === 'FunctionDeclaration' || decl.type === 'ClassDeclaration') {
+						if (decl.id && decl.id.name) {
+							replacements.push(buildExportAssignment(decl.id.name, decl.id.name));
+						}
+					} else if (decl.type === 'VariableDeclaration') {
+						decl.declarations.forEach(function (d) {
+							if (d.id && d.id.name) {
+								replacements.push(buildExportAssignment(d.id.name, d.id.name));
+							}
+						});
+					}
+					path.replaceWithMultiple(replacements);
+					return;
+				}
+
+				// `export { show }` or `export { show as displayShow }` — locally declared
+				// bindings get attached to the controller's local `exports` object.
+				if (node.specifiers && node.specifiers.length !== 0) {
+					var assignments = node.specifiers
+						.filter(function (specifier) { return specifier.local && specifier.local.name; })
+						.map(function (specifier) {
+							var localName = specifier.local.name;
+							var exportedName = (specifier.exported && specifier.exported.name) || localName;
+							return buildExportAssignment(exportedName, localName);
+						});
+					path.replaceWithMultiple(assignments);
+					return;
+				}
+
+				// Fallback: leave as-is at module level.
 				moduleCodes += generate(node, GENCODE_OPTIONS).code;
 				path.remove();
 			}
 		}, path.scope);
-
-		if (exportSpecifiers.length > 0) {
-			traverse(ast, {
-				enter: function(path) {
-					var node = path.node,
-						name;
-					if (node.type === 'VariableDeclaration') {
-						name = node.declarations[0].id.name;
-					} else if (node.type === 'FunctionDeclaration' || node.type === 'ClassDeclaration') {
-						name = node.id.name;
-					}
-
-					if (exportSpecifiers.indexOf(name) !== -1) {
-						moduleCodes += generate(node, GENCODE_OPTIONS).code;
-						path.remove();
-					}
-				}
-			});
-		}
 
 		newCode = generate(ast, GENCODE_OPTIONS).code;
 	} catch (e) {


### PR DESCRIPTION
## Summary

Controllers written with ES6 export syntax (`export function show() {}`, `export const show = () => {}`, `export class X {}`, `export { show }`) silently dropped their exports — only the CommonJS form `exports.show = () => {}` worked. The controller methods existed in the generated file but were never attached to the controller instance, so calling `$.show()` from outside would be `undefined`.

Tested with our app as well!

## Root cause

`Alloy/commands/compile/ast/controller.js` handled `ExportNamedDeclaration` by stripping the entire node out of the controller body and dumping it verbatim into `moduleCodes`. That string is interpolated into the generated component template at **file-module** scope (`Alloy/template/component.js:5`), *above* the `Controller` function.

Inside `Controller()` there is a *local* `var exports = {}` (line 28) that the developer's controller body is supposed to populate; `_.extend($, exports)` (line 55) is what surfaces those names on the controller instance. Because the ES6 exports were hoisted out of the function, they never wrote to this local object and were lost — `module.exports = Controller` at the bottom of the template overrides anything assigned at module scope anyway.

CommonJS `exports.show = ...` worked because it's a plain `AssignmentExpression`, not an `ExportNamedDeclaration`, so no AST handler touched it and it stayed in the controller body.

## Fix

Rewrote the `ExportNamedDeclaration` handler to transform local exports into a declaration + `exports.NAME = NAME` assignment pair, keeping both in the controller body:

- `export function show() {}` → `function show() {} exports.show = show;`
- `export const show = () => {}` → `const show = () => {}; exports.show = show;`
- `export const a = 1, b = 2;` → two assignments
- `export class Foo {}` → `class Foo {} exports.Foo = Foo;`
- `export { show }` → `exports.show = show;` (declaration left in place)
- `export { show as displayShow }` → `exports.displayShow = show;`
- `export { foo } from './bar'` (has a `source`) → still hoisted to module scope as before — it's a true module-level construct
- CommonJS `exports.show = ...` → unchanged

The obsolete second AST traversal that yanked function/variable declarations out of the controller body has been removed.

## Test plan

- [x] CommonJS `exports.show = () => {}` still inlined unchanged (regression check)
- [x] `export function show() {}` produces `function show() {} exports.show = show;`
- [x] `export const show = () => {}` produces `const show = () => {}; exports.show = show;`
- [x] `export const a = 1, b = 2;` produces both `exports.a` and `exports.b` assignments
- [x] `export class Foo {}` produces class declaration + `exports.Foo = Foo`
- [x] `export { show }; function show() {}` keeps the function and adds `exports.show = show`
- [x] `export { show as displayShow }` renames correctly
- [x] `export { foo } from './bar'` stays hoisted to module scope
- [x] Combined `import` + `export` keeps `import` at module scope and rewrites the export
- [x] `exports.baseController = "X"` detection still works
- [x] `npx eslint Alloy/commands/compile/ast/controller.js` clean
- [x] Run an Alloy app that uses `export function` syntax and confirm the method is callable on the controller instance